### PR TITLE
Build debug APK on main pushes

### DIFF
--- a/.github/workflows/build-flutter.yml
+++ b/.github/workflows/build-flutter.yml
@@ -2,10 +2,8 @@ name: Build Flutter APK
 
 on:
   push:
-    paths:
-      - 'mobile/**'
-      - '.github/workflows/build-flutter.yml'
-  pull_request:
+    branches:
+      - main
     paths:
       - 'mobile/**'
       - '.github/workflows/build-flutter.yml'
@@ -37,11 +35,11 @@ jobs:
       - name: Generate code
         run: flutter pub run build_runner build --delete-conflicting-outputs
 
-      - name: Build APK
-        run: flutter build apk --release
+      - name: Build debug APK
+        run: flutter build apk --debug
 
-      - name: Upload artifact
+      - name: Upload debug artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-release-apk
-          path: build/app/outputs/flutter-apk/app-release.apk
+          name: 'marina-hotel-debug-main-${{ github.run_number }}'
+          path: build/app/outputs/flutter-apk/app-debug.apk

--- a/mobile/lib/components/widgets/empty_state.dart
+++ b/mobile/lib/components/widgets/empty_state.dart
@@ -1,21 +1,34 @@
 import 'package:flutter/material.dart';
 
 class EmptyState extends StatelessWidget {
-  const EmptyState({super.key, required this.title, this.subtitle, this.message});
+  const EmptyState({super.key, required this.title, this.subtitle, this.message, this.icon});
   final String title;
   final String? subtitle;
   final String? message;
+  final IconData? icon;
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.outline;
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(Icons.inbox, size: 48, color: Colors.grey),
+          Icon(icon ?? Icons.inbox, size: 48, color: muted),
           const SizedBox(height: 8),
-          Text(title, style: Theme.of(context).textTheme.titleMedium),
-          if (subtitle != null) Text(subtitle!, style: const TextStyle(color: Colors.grey)),
-          if (message != null) Text(message!, style: const TextStyle(color: Colors.grey)),
+          Text(title, style: theme.textTheme.titleMedium, textAlign: TextAlign.center),
+          if (subtitle != null)
+            Text(
+              subtitle!,
+              style: theme.textTheme.bodyMedium?.copyWith(color: muted),
+              textAlign: TextAlign.center,
+            ),
+          if (message != null)
+            Text(
+              message!,
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+              textAlign: TextAlign.center,
+            ),
         ],
       ),
     );

--- a/mobile/lib/screens/bookings/bookings_list.dart
+++ b/mobile/lib/screens/bookings/bookings_list.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
@@ -175,7 +177,7 @@ class _BookingsListScreenState extends ConsumerState<BookingsListScreen> {
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => Directionality(
-        textDirection: TextDirection.rtl,
+        textDirection: ui.TextDirection.rtl,
         child: AlertDialog(
           title: const Text('بحث في الحجوزات'),
           content: TextField(
@@ -562,7 +564,7 @@ class _BookingRow extends ConsumerWidget {
     showDialog(
       context: context,
       builder: (ctx) => Directionality(
-        textDirection: TextDirection.rtl,
+        textDirection: ui.TextDirection.rtl,
         child: StreamBuilder<List<BookingNote>>(
           stream: notesRepo.watchByBooking(booking.id),
           builder: (context, snap) {

--- a/mobile/lib/screens/payments/booking_payment_screen.dart
+++ b/mobile/lib/screens/payments/booking_payment_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -703,7 +705,7 @@ class _BookingPaymentScreenState extends ConsumerState<BookingPaymentScreen>
     showDialog(
       context: context,
       builder: (context) => Directionality(
-        textDirection: TextDirection.rtl,
+        textDirection: ui.TextDirection.rtl,
         child: AlertDialog(
           title: Row(
             children: [
@@ -923,8 +925,9 @@ class _BookingPaymentScreenState extends ConsumerState<BookingPaymentScreen>
 
   void _generateInvoice(BookingPaymentSummary summary) async {
     final checkin = DateTime.tryParse(widget.booking.checkinDate) ?? DateTime.now();
-    final plannedCheckout = widget.booking.checkoutDate != null ? DateTime.tryParse(widget.booking.checkoutDate!) : DateTime.now();
-    final actualCheckout = widget.booking.actualCheckout != null ? DateTime.tryParse(widget.booking.actualCheckout!) : plannedCheckout;
+    final plannedCheckout = widget.booking.checkoutDate != null ? DateTime.tryParse(widget.booking.checkoutDate!) : null;
+    final actualCheckout = widget.booking.actualCheckout != null ? DateTime.tryParse(widget.booking.actualCheckout!) : null;
+    final checkout = actualCheckout ?? plannedCheckout ?? checkin;
     final roomsRepo = ref.read(roomsRepoProvider);
     final room = await roomsRepo.watchByNumber(widget.booking.roomNumber).first;
     final invoice = Invoice(
@@ -934,8 +937,8 @@ class _BookingPaymentScreenState extends ConsumerState<BookingPaymentScreen>
       guestPhone: widget.booking.guestPhone,
       roomNumber: widget.booking.roomNumber,
       checkinDate: checkin,
-      checkoutDate: actualCheckout,
-      nights: Time.nightsWithCutoff(checkin, checkout: actualCheckout),
+      checkoutDate: checkout,
+      nights: Time.nightsWithCutoff(checkin, checkout: checkout),
       roomRate: room?.price ?? 0,
       totalAmount: summary.totalAmount,
       payments: summary.payments,

--- a/mobile/lib/screens/payments/payment_history_screen.dart
+++ b/mobile/lib/screens/payments/payment_history_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../components/app_scaffold.dart';
@@ -6,8 +8,8 @@ import '../../services/local_db.dart';
 import '../../utils/time.dart';
 
 class PaymentHistoryScreen extends ConsumerStatefulWidget {
-  final String bookingId;
-  const PaymentHistoryScreen({super.key, required this.bookingId});
+  final String? bookingId;
+  const PaymentHistoryScreen({super.key, this.bookingId});
 
   @override
   ConsumerState<PaymentHistoryScreen> createState() => _PaymentHistoryScreenState();
@@ -18,14 +20,15 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
   String? _selectedPaymentMethod;
   DateTime? _fromDate;
   DateTime? _toDate;
-  
+
   final List<String> _revenueTypes = ['room', 'service', 'deposit', 'other'];
   final List<String> _paymentMethods = ['نقدي', 'بطاقة', 'تحويل', 'شيك'];
 
   @override
   Widget build(BuildContext context) {
     final paymentsRepo = ref.watch(paymentsRepoProvider);
-    
+    final database = ref.watch(databaseProvider);
+
     return AppScaffold(
       title: 'تاريخ المدفوعات',
       actions: [
@@ -40,281 +43,278 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
       ],
       body: Column(
         children: [
-          // شريط الفلاتر
           if (_hasActiveFilters()) _buildActiveFiltersChips(),
-          
-          // قائمة المدفوعات
           Expanded(
-            child: StreamBuilder<Booking?>(
-              stream: (ref.watch(databaseProvider).select(ref.watch(databaseProvider).bookings)
-                    ..where((t) => t.localUuid.equals(widget.bookingId)))
-                  .watchSingleOrNull(),
-              builder: (context, bookingSnap) {
-                if (bookingSnap.connectionState == ConnectionState.waiting) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-                if (bookingSnap.hasError) {
-                  return Center(child: Text('خطأ في جلب بيانات الحجز: ${bookingSnap.error}'));
-                }
-                final booking = bookingSnap.data;
-                if (booking == null) {
-                  return const Center(child: Text('لم يتم العثور على الحجز'));
-                }
-                return StreamBuilder<List<Payment>>(
-                  stream: paymentsRepo.paymentsByBooking(booking.id),
-                  builder: (context, snapshot) {
-                    if (snapshot.connectionState == ConnectionState.waiting) {
-                      return const Center(child: CircularProgressIndicator());
-                    }
-                    
-                    if (snapshot.hasError) {
-                      return Center(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(
-                              Icons.error_outline,
-                              size: 64,
-                              color: Colors.red.shade300,
-                            ),
-                            const SizedBox(height: 16),
-                            Text(
-                              'حدث خطأ في تحميل البيانات',
-                              style: Theme.of(context).textTheme.titleMedium,
-                            ),
-                            const SizedBox(height: 8),
-                            Text('${snapshot.error}'),
-                            const SizedBox(height: 16),
-                            ElevatedButton(
-                              onPressed: () => setState(() {}),
-                              child: const Text('إعادة المحاولة'),
-                            ),
-                          ],
-                        ),
-                      );
-                    }
-                    
-                    if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                      return const Center(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(
-                              Icons.payment_outlined,
-                              size: 64,
-                              color: Colors.grey,
-                            ),
-                            SizedBox(height: 16),
-                            Text(
-                              'لا توجد مدفوعات مسجلة',
-                              style: TextStyle(
-                                fontSize: 18,
-                                color: Colors.grey,
-                              ),
-                            ),
-                            SizedBox(height: 8),
-                            Text(
-                              'عند إضافة مدفوعات جديدة ستظهر هنا',
-                              style: TextStyle(color: Colors.grey),
-                            ),
-                          ],
-                        ),
-                      );
-                    }
-                    
-                    List<Payment> payments = snapshot.data!;
-                    
-                    // تطبيق الفلاتر
-                    payments = _applyFilters(payments);
-                    
-                    if (payments.isEmpty) {
-                      return const Center(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(
-                              Icons.filter_list_off,
-                              size: 64,
-                              color: Colors.grey,
-                            ),
-                            SizedBox(height: 16),
-                            Text(
-                              'لا توجد مدفوعات تطابق الفلاتر المحددة',
-                              style: TextStyle(
-                                fontSize: 16,
-                                color: Colors.grey,
-                              ),
-                            ),
-                            SizedBox(height: 8),
-                            Text(
-                              'جرب تعديل الفلاتر أو إزالتها',
-                              style: TextStyle(color: Colors.grey),
-                            ),
-                          ],
-                        ),
-                      );
-                    }
-                    
-                    // حساب الإجمالي
-                    final totalAmount = payments.fold<double>(
-                      0, 
-                      (sum, payment) => sum + payment.amount,
-                    );
-                    
-                    return Column(
-                      children: [
-                        // شريط الإحصائيات
-                        Container(
-                          width: double.infinity,
-                          margin: const EdgeInsets.all(16),
-                          padding: const EdgeInsets.all(16),
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              colors: [Colors.green.shade400, Colors.green.shade600],
-                            ),
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: Column(
-                            children: [
-                              Text(
-                                'إجمالي المدفوعات',
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 16,
-                                ),
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                '${totalAmount.toStringAsFixed(2)}',
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 24,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                'عدد المدفوعات: ${payments.length}',
-                                style: const TextStyle(
-                                  color: Colors.white70,
-                                  fontSize: 14,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        
-                        // قائمة المدفوعات
-                        Expanded(
-                          child: ListView.builder(
-                            padding: const EdgeInsets.symmetric(horizontal: 16),
-                            itemCount: payments.length,
-                            itemBuilder: (context, index) {
-                              final payment = payments[index];
-                              return Card(
-                                margin: const EdgeInsets.only(bottom: 8),
-                                child: ListTile(
-                                  leading: Container(
-                                    padding: const EdgeInsets.all(8),
-                                    decoration: BoxDecoration(
-                                      color: _getPaymentMethodColor(payment.paymentMethod).withOpacity(0.2),
-                                      borderRadius: BorderRadius.circular(8),
-                                    ),
-                                    child: Icon(
-                                      _getPaymentMethodIcon(payment.paymentMethod),
-                                      color: _getPaymentMethodColor(payment.paymentMethod),
-                                    ),
-                                  ),
-                                  title: Text(
-                                    '${payment.amount.toStringAsFixed(2)}',
-                                    style: const TextStyle(
-                                      fontWeight: FontWeight.bold,
-                                      fontSize: 16,
-                                    ),
-                                  ),
-                                  subtitle: Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
-                                    children: [
-                                      const SizedBox(height: 4),
-                                      Row(
-                                        children: [
-                                          Icon(Icons.payment, size: 16, color: Colors.grey.shade600),
-                                          const SizedBox(width: 4),
-                                          Text(
-                                            payment.paymentMethod,
-                                            style: TextStyle(color: Colors.grey.shade700),
-                                          ),
-                                          const SizedBox(width: 12),
-                                          Icon(Icons.category, size: 16, color: Colors.grey.shade600),
-                                          const SizedBox(width: 4),
-                                          Text(
-                                            _getRevenueTypeLabel(payment.revenueType),
-                                            style: TextStyle(color: Colors.grey.shade700),
-                                          ),
-                                        ],
-                                      ),
-                                      const SizedBox(height: 2),
-                                      Row(
-                                        children: [
-                                          Icon(Icons.calendar_today, size: 16, color: Colors.grey.shade600),
-                                          const SizedBox(width: 4),
-                                          Text(
-                                            payment.paymentDate,
-                                            style: TextStyle(color: Colors.grey.shade700),
-                                          ),
-                                        ],
-                                      ),
-                                      if (payment.notes != null && payment.notes!.isNotEmpty) ...[
-                                        const SizedBox(height: 2),
-                                        Row(
-                                          children: [
-                                            Icon(Icons.note, size: 16, color: Colors.grey.shade600),
-                                            const SizedBox(width: 4),
-                                            Expanded(
-                                              child: Text(
-                                                payment.notes!,
-                                                style: TextStyle(
-                                                  color: Colors.grey.shade700,
-                                                  fontStyle: FontStyle.italic,
-                                                ),
-                                              ),
-                                            ),
-                                          ],
-                                        ),
-                                      ],
-                                    ],
-                                  ),
-                                  trailing: payment.roomNumber != null 
-                                      ? Chip(
-                                          label: Text(payment.roomNumber!),
-                                          backgroundColor: Colors.blue.shade50,
-                                        )
-                                      : null,
-                                  onTap: () => _showPaymentDetails(payment),
-                                ),
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    );
-                  },
-                );
-              },
-            ),
+            child: widget.bookingId == null
+                ? _buildPaymentsList(paymentsRepo.watchAll())
+                : StreamBuilder<Booking?>(
+                    stream: (database.select(database.bookings)
+                          ..where((t) => t.localUuid.equals(widget.bookingId!)))
+                        .watchSingleOrNull(),
+                    builder: (context, bookingSnap) {
+                      if (bookingSnap.connectionState == ConnectionState.waiting) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+                      if (bookingSnap.hasError) {
+                        return Center(child: Text('خطأ في جلب بيانات الحجز: ${bookingSnap.error}'));
+                      }
+                      final booking = bookingSnap.data;
+                      if (booking == null) {
+                        return const Center(child: Text('لم يتم العثور على الحجز'));
+                      }
+                      return _buildPaymentsList(paymentsRepo.paymentsByBooking(booking.id));
+                    },
+                  ),
           ),
         ],
       ),
     );
   }
-  
-  bool _hasActiveFilters() {
-    return _selectedRevenueType != null || 
-           _selectedPaymentMethod != null || 
-           _fromDate != null || 
-           _toDate != null;
+
+  Widget _buildPaymentsList(Stream<List<Payment>> stream) {
+    return StreamBuilder<List<Payment>>(
+      stream: stream,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.error_outline,
+                  size: 64,
+                  color: Colors.red.shade300,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'حدث خطأ في تحميل البيانات',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Text('${snapshot.error}'),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () => setState(() {}),
+                  child: const Text('إعادة المحاولة'),
+                ),
+              ],
+            ),
+          );
+        }
+
+        if (!snapshot.hasData || snapshot.data!.isEmpty) {
+          return const Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.payment_outlined,
+                  size: 64,
+                  color: Colors.grey,
+                ),
+                SizedBox(height: 16),
+                Text(
+                  'لا توجد مدفوعات مسجلة',
+                  style: TextStyle(
+                    fontSize: 18,
+                    color: Colors.grey,
+                  ),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  'عند إضافة مدفوعات جديدة ستظهر هنا',
+                  style: TextStyle(color: Colors.grey),
+                ),
+              ],
+            ),
+          );
+        }
+
+        var payments = snapshot.data!;
+        payments = _applyFilters(payments);
+
+        if (payments.isEmpty) {
+          return const Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.filter_list_off,
+                  size: 64,
+                  color: Colors.grey,
+                ),
+                SizedBox(height: 16),
+                Text(
+                  'لا توجد مدفوعات تطابق الفلاتر المحددة',
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: Colors.grey,
+                  ),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  'جرب تعديل الفلاتر أو إزالتها',
+                  style: TextStyle(color: Colors.grey),
+                ),
+              ],
+            ),
+          );
+        }
+
+        final totalAmount = payments.fold<double>(
+          0,
+          (sum, payment) => sum + payment.amount,
+        );
+
+        return Column(
+          children: [
+            Container(
+              width: double.infinity,
+              margin: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [Colors.green.shade400, Colors.green.shade600],
+                ),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Column(
+                children: [
+                  const Text(
+                    'إجمالي المدفوعات',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${totalAmount.toStringAsFixed(2)}',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'عدد المدفوعات: ${payments.length}',
+                    style: const TextStyle(
+                      color: Colors.white70,
+                      fontSize: 14,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView.builder(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: payments.length,
+                itemBuilder: (context, index) {
+                  final payment = payments[index];
+                  return Card(
+                    margin: const EdgeInsets.only(bottom: 8),
+                    child: ListTile(
+                      leading: Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: _getPaymentMethodColor(payment.paymentMethod).withOpacity(0.2),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Icon(
+                          _getPaymentMethodIcon(payment.paymentMethod),
+                          color: _getPaymentMethodColor(payment.paymentMethod),
+                        ),
+                      ),
+                      title: Text(
+                        '${payment.amount.toStringAsFixed(2)}',
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
+                      ),
+                      subtitle: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const SizedBox(height: 4),
+                          Row(
+                            children: [
+                              Icon(Icons.payment, size: 16, color: Colors.grey.shade600),
+                              const SizedBox(width: 4),
+                              Text(
+                                payment.paymentMethod,
+                                style: TextStyle(color: Colors.grey.shade700),
+                              ),
+                              const SizedBox(width: 12),
+                              Icon(Icons.category, size: 16, color: Colors.grey.shade600),
+                              const SizedBox(width: 4),
+                              Text(
+                                _getRevenueTypeLabel(payment.revenueType),
+                                style: TextStyle(color: Colors.grey.shade700),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 2),
+                          Row(
+                            children: [
+                              Icon(Icons.calendar_today, size: 16, color: Colors.grey.shade600),
+                              const SizedBox(width: 4),
+                              Text(
+                                payment.paymentDate,
+                                style: TextStyle(color: Colors.grey.shade700),
+                              ),
+                            ],
+                          ),
+                          if (payment.notes != null && payment.notes!.isNotEmpty) ...[
+                            const SizedBox(height: 2),
+                            Row(
+                              children: [
+                                Icon(Icons.note, size: 16, color: Colors.grey.shade600),
+                                const SizedBox(width: 4),
+                                Expanded(
+                                  child: Text(
+                                    payment.notes!,
+                                    style: TextStyle(
+                                      color: Colors.grey.shade700,
+                                      fontStyle: FontStyle.italic,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ],
+                      ),
+                      trailing: payment.roomNumber != null
+                          ? Chip(
+                              label: Text(payment.roomNumber!),
+                              backgroundColor: Colors.blue.shade50,
+                            )
+                          : null,
+                      onTap: () => _showPaymentDetails(payment),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        );
+      },
+    );
   }
-  
+
+  bool _hasActiveFilters() {
+    return _selectedRevenueType != null ||
+        _selectedPaymentMethod != null ||
+        _fromDate != null ||
+        _toDate != null;
+  }
+
   Widget _buildActiveFiltersChips() {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -345,22 +345,17 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
       ),
     );
   }
-  
+
   List<Payment> _applyFilters(List<Payment> payments) {
     return payments.where((payment) {
-      // فلتر نوع الإيراد
-      if (_selectedRevenueType != null && 
-          payment.revenueType != _selectedRevenueType) {
+      if (_selectedRevenueType != null && payment.revenueType != _selectedRevenueType) {
         return false;
       }
-      
-      // فلتر طريقة الدفع
-      if (_selectedPaymentMethod != null && 
-          payment.paymentMethod != _selectedPaymentMethod) {
+
+      if (_selectedPaymentMethod != null && payment.paymentMethod != _selectedPaymentMethod) {
         return false;
       }
-      
-      // فلتر التاريخ
+
       if (_fromDate != null || _toDate != null) {
         try {
           final paymentDate = DateTime.parse(payment.paymentDate);
@@ -370,20 +365,18 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
           if (_toDate != null && paymentDate.isAfter(_toDate!)) {
             return false;
           }
-        } catch (e) {
-          // إذا فشل تحليل التاريخ، تجاهل هذا الفلتر
-        }
+        } catch (e) {}
       }
-      
+
       return true;
     }).toList();
   }
-  
+
   void _showFilterDialog() {
     showDialog(
       context: context,
       builder: (ctx) => Directionality(
-        textDirection: TextDirection.rtl,
+        textDirection: ui.TextDirection.rtl,
         child: StatefulBuilder(
           builder: (context, setDialogState) => AlertDialog(
             title: const Text('فلترة المدفوعات'),
@@ -391,7 +384,6 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  // فلتر نوع الإيراد
                   DropdownButtonFormField<String>(
                     value: _selectedRevenueType,
                     decoration: const InputDecoration(
@@ -401,16 +393,13 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                     items: [
                       const DropdownMenuItem(value: null, child: Text('جميع الأنواع')),
                       ..._revenueTypes.map((type) => DropdownMenuItem(
-                        value: type, 
-                        child: Text(_getRevenueTypeLabel(type)),
-                      )),
+                            value: type,
+                            child: Text(_getRevenueTypeLabel(type)),
+                          )),
                     ],
                     onChanged: (value) => setDialogState(() => _selectedRevenueType = value),
                   ),
-                  
                   const SizedBox(height: 16),
-                  
-                  // فلتر طريقة الدفع
                   DropdownButtonFormField<String>(
                     value: _selectedPaymentMethod,
                     decoration: const InputDecoration(
@@ -420,16 +409,13 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                     items: [
                       const DropdownMenuItem(value: null, child: Text('جميع الطرق')),
                       ..._paymentMethods.map((method) => DropdownMenuItem(
-                        value: method, 
-                        child: Text(method),
-                      )),
+                            value: method,
+                            child: Text(method),
+                          )),
                     ],
                     onChanged: (value) => setDialogState(() => _selectedPaymentMethod = value),
                   ),
-                  
                   const SizedBox(height: 16),
-                  
-                  // فلتر التاريخ من
                   ListTile(
                     title: const Text('من تاريخ'),
                     subtitle: Text(_fromDate != null ? Time.dateToString(_fromDate!) : 'غير محدد'),
@@ -446,8 +432,6 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                       }
                     },
                   ),
-                  
-                  // فلتر التاريخ إلى
                   ListTile(
                     title: const Text('إلى تاريخ'),
                     subtitle: Text(_toDate != null ? Time.dateToString(_toDate!) : 'غير محدد'),
@@ -474,7 +458,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
               ),
               ElevatedButton(
                 onPressed: () {
-                  setState(() {}); // تحديث الشاشة الرئيسية
+                  setState(() {});
                   Navigator.of(ctx).pop();
                 },
                 child: const Text('تطبيق الفلاتر'),
@@ -485,7 +469,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
       ),
     );
   }
-  
+
   void _clearFilters() {
     setState(() {
       _selectedRevenueType = null;
@@ -494,12 +478,12 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
       _toDate = null;
     });
   }
-  
+
   void _showPaymentDetails(Payment payment) {
     showDialog(
       context: context,
       builder: (ctx) => Directionality(
-        textDirection: TextDirection.rtl,
+        textDirection: ui.TextDirection.rtl,
         child: AlertDialog(
           title: const Text('تفاصيل الدفعة'),
           content: Column(
@@ -526,7 +510,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
       ),
     );
   }
-  
+
   Widget _buildDetailRow(String label, String value) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -546,7 +530,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
       ),
     );
   }
-  
+
   String _getRevenueTypeLabel(String type) {
     switch (type) {
       case 'room':
@@ -561,7 +545,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
         return type;
     }
   }
-  
+
   Color _getPaymentMethodColor(String method) {
     switch (method) {
       case 'نقدي':
@@ -576,7 +560,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
         return Colors.grey;
     }
   }
-  
+
   IconData _getPaymentMethodIcon(String method) {
     switch (method) {
       case 'نقدي':

--- a/mobile/lib/services/repositories/payments_repository.dart
+++ b/mobile/lib/services/repositories/payments_repository.dart
@@ -12,6 +12,7 @@ class PaymentsRepository {
   final PaymentsDao dao;
 
   Stream<List<Payment>> paymentsByBooking(int bookingLocalId) => dao.watchList(bookingLocalId: bookingLocalId);
+  Stream<List<Payment>> watchAll({bool includeDeleted = false}) => dao.watchList(includeDeleted: includeDeleted);
   Stream<Payment?> watchOne(int id) => dao.watchById(id);
 
   Future<int> create({int? bookingLocalId, int? serverBookingId, String? roomNumber, required double amount, required String paymentDate, String? notes, required String paymentMethod, required String revenueType}) => dao.insertOne(


### PR DESCRIPTION
## Summary
- switch the Flutter workflow to build unsigned debug APKs on pushes to `main`
- align UI helpers with the latest Flutter/Dart expectations so automated builds succeed
- let the payments history screen operate without a booking id to support existing navigation

## Testing
- GitHub Actions: Build Flutter APK (https://github.com/NassarAlshabi1/marina-hotel-wit-app/actions/runs/18569269246) — rerun still fails until the base branch incorporates these fixes


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/12f95353-e822-4a5a-92b4-4770fc1007b6/task/4d446f1c-0c43-4d1d-9b6a-7ad0111dc183))