### PR TITLE
Local auth + permissions (Arabic RTL) for Flutter mobile

### DIFF
--- a/mobile/lib/components/admin_sidebar.dart
+++ b/mobile/lib/components/admin_sidebar.dart
@@ -16,7 +16,13 @@ class AdminSidebar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final auth = ref.watch(authProvider);
-    
+    bool can(String key) {
+      final u = auth.currentUser;
+      if (u == null) return false;
+      if (u.permissions.contains('all') || u.userType == 'admin') return true;
+      return u.permissions.contains(key);
+    }
+
     return Container(
       width: 280,
       color: AppColors.primaryColor,
@@ -117,78 +123,102 @@ class AdminSidebar extends ConsumerWidget {
             child: ListView(
               padding: const EdgeInsets.symmetric(vertical: 16),
               children: [
-                _buildMenuItem(
-                  icon: Icons.dashboard,
-                  title: 'لوحة التحكم',
-                  route: '/dashboard',
-                  isActive: currentRoute == '/dashboard',
-                  onTap: () => onRouteSelected('/dashboard'),
-                ),
-                _buildMenuItem(
-                  icon: Icons.bed,
-                  title: 'إدارة الغرف',
-                  route: '/rooms',
-                  isActive: currentRoute.startsWith('/rooms'),
-                  onTap: () => onRouteSelected('/rooms'),
-                ),
-                _buildMenuItem(
-                  icon: Icons.assignment,
-                  title: 'إدارة الحجوزات',
-                  route: '/bookings',
-                  isActive: currentRoute.startsWith('/bookings'),
-                  onTap: () => onRouteSelected('/bookings'),
-                ),
-                _buildMenuItem(
-                  icon: Icons.attach_money,
-                  title: 'إدارة المدفوعات',
-                  route: '/payments',
-                  isActive: currentRoute.startsWith('/payments'),
-                  onTap: () => onRouteSelected('/payments'),
-                ),
-                _buildMenuItem(
-                  icon: Icons.group,
-                  title: 'إدارة الموظفين',
-                  route: '/employees',
-                  isActive: currentRoute.startsWith('/employees'),
-                  onTap: () => onRouteSelected('/employees'),
-                ),
-                _buildMenuItem(
-                  icon: Icons.receipt_long,
-                  title: 'إدارة المصروفات',
-                  route: '/expenses',
-                  isActive: currentRoute.startsWith('/expenses'),
-                  onTap: () => onRouteSelected('/expenses'),
-                ),
-                _buildMenuItem(
-                  icon: Icons.account_balance_wallet,
-                  title: 'الصندوق والمالية',
-                  route: '/finance',
-                  isActive: currentRoute.startsWith('/finance'),
-                  onTap: () => onRouteSelected('/finance'),
-                ),
-                _buildMenuItem(
-                  icon: Icons.bar_chart,
-                  title: 'التقارير',
-                  route: '/reports',
-                  isActive: currentRoute.startsWith('/reports'),
-                  onTap: () => onRouteSelected('/reports'),
-                ),
-                _buildMenuItem(
-                  icon: Icons.note,
-                  title: 'الملاحظات والتنبيهات',
-                  route: '/notes',
-                  isActive: currentRoute.startsWith('/notes'),
-                  onTap: () => onRouteSelected('/notes'),
-                ),
-                _buildMenuItem(
-                  icon: Icons.settings,
-                  title: 'الإعدادات',
-                  route: '/settings',
-                  isActive: currentRoute.startsWith('/settings'),
-                  onTap: () => onRouteSelected('/settings'),
-                ),
-                
+                if (can('dashboard'))
+                  _buildMenuItem(
+                    icon: Icons.dashboard,
+                    title: 'لوحة التحكم',
+                    route: '/dashboard',
+                    isActive: currentRoute == '/dashboard',
+                    onTap: () => onRouteSelected('/dashboard'),
+                  ),
+                if (can('rooms'))
+                  _buildMenuItem(
+                    icon: Icons.bed,
+                    title: 'إدارة الغرف',
+                    route: '/rooms',
+                    isActive: currentRoute.startsWith('/rooms'),
+                    onTap: () => onRouteSelected('/rooms'),
+                  ),
+                if (can('bookings'))
+                  _buildMenuItem(
+                    icon: Icons.assignment,
+                    title: 'إدارة الحجوزات',
+                    route: '/bookings',
+                    isActive: currentRoute.startsWith('/bookings'),
+                    onTap: () => onRouteSelected('/bookings'),
+                  ),
+                if (can('payments'))
+                  _buildMenuItem(
+                    icon: Icons.attach_money,
+                    title: 'إدارة المدفوعات',
+                    route: '/payments',
+                    isActive: currentRoute.startsWith('/payments'),
+                    onTap: () => onRouteSelected('/payments'),
+                  ),
+                if (can('employees'))
+                  _buildMenuItem(
+                    icon: Icons.group,
+                    title: 'إدارة الموظفين',
+                    route: '/employees',
+                    isActive: currentRoute.startsWith('/employees'),
+                    onTap: () => onRouteSelected('/employees'),
+                  ),
+                if (can('expenses'))
+                  _buildMenuItem(
+                    icon: Icons.receipt_long,
+                    title: 'إدارة المصروفات',
+                    route: '/expenses',
+                    isActive: currentRoute.startsWith('/expenses'),
+                    onTap: () => onRouteSelected('/expenses'),
+                  ),
+                if (can('finance'))
+                  _buildMenuItem(
+                    icon: Icons.account_balance_wallet,
+                    title: 'الصندوق والمالية',
+                    route: '/finance',
+                    isActive: currentRoute.startsWith('/finance'),
+                    onTap: () => onRouteSelected('/finance'),
+                  ),
+                if (can('reports'))
+                  _buildMenuItem(
+                    icon: Icons.bar_chart,
+                    title: 'التقارير',
+                    route: '/reports',
+                    isActive: currentRoute.startsWith('/reports'),
+                    onTap: () => onRouteSelected('/reports'),
+                  ),
+                if (can('notes'))
+                  _buildMenuItem(
+                    icon: Icons.note,
+                    title: 'الملاحظات والتنبيهات',
+                    route: '/notes',
+                    isActive: currentRoute.startsWith('/notes'),
+                    onTap: () => onRouteSelected('/notes'),
+                  ),
+                if (can('settings'))
+                  _buildMenuItem(
+                    icon: Icons.settings,
+                    title: 'الإعدادات',
+                    route: '/settings',
+                    isActive: currentRoute.startsWith('/settings'),
+                    onTap: () => onRouteSelected('/settings'),
+                  ),
               ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: _buildMenuItem(
+              icon: Icons.logout,
+              title: 'تسجيل الخروج',
+              route: '/logout',
+              isActive: false,
+              onTap: () async {
+                await ref.read(authProvider.notifier).logout();
+                if (Navigator.of(context).canPop()) {
+                  Navigator.of(context).pop();
+                }
+              },
             ),
           ),
         ],

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -13,6 +13,8 @@ import 'screens/reports/reports_screen.dart';
 import 'screens/payments/payments_main_screen.dart';
 import 'screens/notes/notes_screen.dart';
 import 'screens/settings/settings_screen.dart';
+import 'screens/auth/login_screen.dart';
+import 'providers/auth_provider.dart';
 import 'services/providers.dart';
 import 'services/seed.dart';
 import 'services/auto_backup_task.dart';
@@ -53,19 +55,39 @@ class App extends ConsumerWidget {
           '/finance/cash-transactions': (_) => const FinanceScreen(),
           '/reports': (_) => const ReportsScreen(),
         },
-        home: const HomeShell(),
+        home: const RootRouter(),
       ),
     );
   }
 }
 
-class HomeShell extends StatefulWidget {
-  const HomeShell({super.key});
+class RootRouter extends ConsumerWidget {
+  const RootRouter({super.key});
   @override
-  State<HomeShell> createState() => _HomeShellState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authProvider);
+    if (auth.isRestoring) {
+      return const Directionality(
+        textDirection: TextDirection.rtl,
+        child: Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+    if (auth.isAuthenticated) {
+      return const HomeShell();
+    }
+    return const LoginScreen();
+  }
 }
 
-class _HomeShellState extends State<HomeShell> {
+class HomeShell extends ConsumerStatefulWidget {
+  const HomeShell({super.key});
+  @override
+  ConsumerState<HomeShell> createState() => _HomeShellState();
+}
+
+class _HomeShellState extends ConsumerState<HomeShell> {
   String _currentRoute = '/dashboard';
   
   final Map<String, Widget> _routes = {
@@ -81,11 +103,25 @@ class _HomeShellState extends State<HomeShell> {
     '/settings': const SettingsScreen(),
   };
   
+  bool _can(String key) {
+    final auth = ref.read(authProvider);
+    final u = auth.currentUser;
+    if (u == null) return false;
+    if (u.userType == 'admin' || u.permissions.contains('all')) return true;
+    return u.permissions.contains(key);
+  }
+
   @override
   Widget build(BuildContext context) {
+    final routeKey = _currentRoute.replaceAll('/', '');
+    final allowed = _can(routeKey.isEmpty ? 'dashboard' : routeKey);
+    final body = allowed
+        ? (_routes[_currentRoute] ?? const DashboardScreen())
+        : const Center(child: Text('ليس لديك صلاحية لعرض هذه الصفحة'));
+
     return AdminLayout(
       currentRoute: _currentRoute,
-      body: _routes[_currentRoute] ?? const DashboardScreen(),
+      body: body,
       onRouteSelected: _navigateToRoute,
     );
   }

--- a/mobile/lib/providers/auth_provider.dart
+++ b/mobile/lib/providers/auth_provider.dart
@@ -1,6 +1,5 @@
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../services/api_service.dart';
+import '../services/auth_local_store.dart';
 
 class AuthUser {
   final int id;
@@ -18,6 +17,8 @@ class AuthUser {
   });
 
   String get name => fullName.isNotEmpty ? fullName : username;
+
+  bool get isAdmin => userType == 'admin' || permissions.contains('all');
 
   factory AuthUser.fromJson(Map<String, dynamic> json) {
     final rawPerms = json['permissions'];
@@ -40,60 +41,95 @@ class AuthUser {
           : const <String>[],
     );
   }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'username': username,
+        'full_name': fullName,
+        'user_type': userType,
+        'permissions': permissions,
+      };
+
+  AuthUser copyWith({
+    List<String>? permissions,
+  }) {
+    return AuthUser(
+      id: id,
+      username: username,
+      fullName: fullName,
+      userType: userType,
+      permissions: permissions ?? this.permissions,
+    );
+  }
 }
 
 class AuthState {
   final bool isAuthenticated;
+  final bool isRestoring;
   final String? error;
   final AuthUser? currentUser;
-  const AuthState(this.isAuthenticated, {this.error, this.currentUser});
+  const AuthState({
+    required this.isAuthenticated,
+    this.isRestoring = false,
+    this.error,
+    this.currentUser,
+  });
+
+  AuthState copyWith({
+    bool? isAuthenticated,
+    bool? isRestoring,
+    String? error,
+    AuthUser? currentUser,
+  }) => AuthState(
+        isAuthenticated: isAuthenticated ?? this.isAuthenticated,
+        isRestoring: isRestoring ?? this.isRestoring,
+        error: error,
+        currentUser: currentUser ?? this.currentUser,
+      );
 }
 
 class AuthNotifier extends StateNotifier<AuthState> {
-  AuthNotifier() : super(const AuthState(true, currentUser: _defaultUser));
+  AuthNotifier() : super(const AuthState(isAuthenticated: false, isRestoring: true)) {
+    restoreSession();
+  }
 
-  static const AuthUser _defaultUser = AuthUser(
-    id: 0,
-    username: 'admin',
-    fullName: 'مدير النظام',
-    userType: 'admin',
-    permissions: const ['all'],
-  );
+  final _store = AuthLocalStore();
+
+  Future<void> restoreSession() async {
+    state = state.copyWith(isRestoring: true, error: null);
+    final json = await _store.loadCurrentUser();
+    if (json == null) {
+      state = const AuthState(isAuthenticated: false, isRestoring: false);
+      return;
+    }
+    final user = AuthUser.fromJson(json);
+    state = AuthState(isAuthenticated: true, isRestoring: false, currentUser: user);
+  }
 
   Future<void> login(String username, String password) async {
-    try {
-      final userData = await ApiService.I.login(username, password);
-      if (userData != null) {
-        final user = AuthUser.fromJson(userData);
-        state = AuthState(true, currentUser: user);
-      } else {
-        state = const AuthState(false, error: 'بيانات الدخول غير صحيحة');
-      }
-    } on DioException catch (e) {
-      if (e.response?.statusCode == 401) {
-        state = const AuthState(true, currentUser: _defaultUser, error: 'بيانات الدخول غير صحيحة');
-        return;
-      }
-      state = AuthState(true, currentUser: _defaultUser, error: _errorMessage(e));
-    } catch (_) {
-      state = const AuthState(true, currentUser: _defaultUser, error: 'حدث خطأ غير متوقع');
+    state = state.copyWith(error: null);
+    final data = await _store.validateCredentials(username, password);
+    if (data == null) {
+      state = AuthState(isAuthenticated: false, isRestoring: false, error: 'اسم المستخدم أو كلمة المرور غير صحيحة');
+      return;
     }
+    final user = AuthUser.fromJson(data);
+    await _store.saveCurrentUser(user.toJson());
+    state = AuthState(isAuthenticated: true, isRestoring: false, currentUser: user);
   }
 
   Future<void> logout() async {
-    await ApiService.I.logout();
-    state = const AuthState(true, currentUser: _defaultUser);
+    await _store.clearSession();
+    state = const AuthState(isAuthenticated: false, isRestoring: false);
   }
 
-  String _errorMessage(DioException e) {
-    final data = e.response?.data;
-    if (data is Map && data['error'] is String) {
-      return data['error'] as String;
+  Future<void> updateUserPermissions(String username, List<String> permissions) async {
+    await _store.setPermissions(username, permissions);
+    if (state.currentUser != null && state.currentUser!.username == username) {
+      final updated = state.currentUser!.copyWith(permissions: username == 'admin' ? ['all'] : permissions);
+      await _store.saveCurrentUser(updated.toJson());
+      state = state.copyWith(currentUser: updated);
     }
-    if (e.message != null && e.message!.isNotEmpty) {
-      return e.message!;
-    }
-    return 'تعذر الاتصال بالخادم';
   }
 }
 

--- a/mobile/lib/screens/auth/login_screen.dart
+++ b/mobile/lib/screens/auth/login_screen.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../providers/auth_provider.dart';
+import '../../utils/theme.dart';
+import '../../components/admin_layout.dart';
+
+class LoginScreen extends ConsumerStatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  ConsumerState<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends ConsumerState<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _usernameCtrl = TextEditingController();
+  final _passwordCtrl = TextEditingController();
+  bool _obscure = true;
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _usernameCtrl.dispose();
+    _passwordCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = ref.watch(authProvider);
+
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Scaffold(
+        backgroundColor: AppColors.backgroundColor,
+        body: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Form(
+                    key: _formKey,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Row(
+                          children: const [
+                            Icon(Icons.lock, size: 28, color: AppColors.primaryColor),
+                            SizedBox(width: 8),
+                            Text('تسجيل الدخول', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        TextFormField(
+                          controller: _usernameCtrl,
+                          decoration: const InputDecoration(
+                            labelText: 'اسم المستخدم',
+                            hintText: 'أدخل اسم المستخدم',
+                          ),
+                          validator: (v) => (v == null || v.trim().isEmpty) ? 'يرجى إدخال اسم المستخدم' : null,
+                        ),
+                        const SizedBox(height: 12),
+                        TextFormField(
+                          controller: _passwordCtrl,
+                          obscureText: _obscure,
+                          decoration: InputDecoration(
+                            labelText: 'كلمة المرور',
+                            hintText: 'أدخل كلمة المرور',
+                            suffixIcon: IconButton(
+                              icon: Icon(_obscure ? Icons.visibility : Icons.visibility_off),
+                              onPressed: () => setState(() => _obscure = !_obscure),
+                            ),
+                          ),
+                          validator: (v) => (v == null || v.isEmpty) ? 'يرجى إدخال كلمة المرور' : null,
+                        ),
+                        const SizedBox(height: 16),
+                        if (auth.error != null) ...[
+                          Text(auth.error!, style: const TextStyle(color: AppColors.dangerColor)),
+                          const SizedBox(height: 8),
+                        ],
+                        ElevatedButton(
+                          onPressed: _submitting ? null : _onSubmit,
+                          child: _submitting
+                              ? const SizedBox(height: 18, width: 18, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                              : const Text('دخول'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _onSubmit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _submitting = true);
+    await ref.read(authProvider.notifier).login(_usernameCtrl.text.trim(), _passwordCtrl.text);
+    setState(() => _submitting = false);
+    final state = ref.read(authProvider);
+    // سيقوم RootRouter بإظهار الواجهة الرئيسية تلقائيًا عند نجاح الدخول
+  }
+}

--- a/mobile/lib/screens/rooms/rooms_list.dart
+++ b/mobile/lib/screens/rooms/rooms_list.dart
@@ -8,6 +8,7 @@ import 'package:uuid/uuid.dart';
 import 'package:drift/drift.dart' as d;
 import 'package:image_picker/image_picker.dart';
 import '../../services/api_service.dart';
+import '../../providers/auth_provider.dart';
 
 Future<ImagePicker> _lazyPicker() async => ImagePicker();
 
@@ -16,6 +17,10 @@ class RoomsListScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final roomsStream = ref.watch(roomsListProvider);
+    final auth = ref.watch(authProvider);
+    final canRooms = auth.currentUser?.permissions.contains('all') == true ||
+        auth.currentUser?.userType == 'admin' ||
+        (auth.currentUser?.permissions.contains('rooms') ?? false);
     return AppScaffold(
       title: 'الغرف',
       actions: [
@@ -23,12 +28,13 @@ class RoomsListScreen extends ConsumerWidget {
           onPressed: () => ref.read(syncServiceProvider).runSync(),
           icon: const Icon(Icons.sync),
         ),
-        IconButton(
-          onPressed: () async {
-            await _editRoom(context, ref);
-          },
-          icon: const Icon(Icons.add),
-        )
+        if (canRooms)
+          IconButton(
+            onPressed: () async {
+              await _editRoom(context, ref);
+            },
+            icon: const Icon(Icons.add),
+          )
       ],
       body: roomsStream.when(
         loading: () => const Center(child: CircularProgressIndicator()),
@@ -41,10 +47,12 @@ class RoomsListScreen extends ConsumerWidget {
               return ListTile(
                 title: Text('${r.roomNumber} • ${r.type}'),
                 subtitle: Text('السعر: ${r.price.toStringAsFixed(2)} • الحالة: ${r.status}'),
-                trailing: IconButton(
-                  icon: const Icon(Icons.edit),
-                  onPressed: () => _editRoom(context, ref, existing: r),
-                ),
+                trailing: canRooms
+                    ? IconButton(
+                        icon: const Icon(Icons.edit),
+                        onPressed: () => _editRoom(context, ref, existing: r),
+                      )
+                    : null,
               );
             },
           );

--- a/mobile/lib/screens/settings/settings_users.dart
+++ b/mobile/lib/screens/settings/settings_users.dart
@@ -1,360 +1,197 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../components/app_scaffold.dart';
+import '../../providers/auth_provider.dart';
+import '../../services/auth_local_store.dart';
 
 class SettingsUsersScreen extends ConsumerWidget {
   const SettingsUsersScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authProvider);
+    final isAdmin = auth.currentUser?.isAdmin == true;
+
     return AppScaffold(
-      title: 'إدارة المستخدمين',
+      title: 'إدارة المستخدمين والصلاحيات',
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // بطاقة معلومات المستخدم الحالي
             Card(
               child: Padding(
                 padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                child: Row(
                   children: [
-                    const Row(
-                      children: [
-                        Icon(Icons.account_circle, size: 32, color: Colors.blue),
-                        SizedBox(width: 12),
-                        Text(
-                          'المستخدم الحالي',
-                          style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                        ),
-                      ],
+                    const Icon(Icons.account_circle, size: 32, color: Colors.blue),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(auth.currentUser?.name ?? 'غير معروف', style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                          Text(isAdmin ? 'مدير النظام' : (auth.currentUser?.userType ?? '')),
+                        ],
+                      ),
                     ),
-                    const SizedBox(height: 16),
-                    _buildInfoRow('اسم المستخدم:', 'admin'),
-                    _buildInfoRow('الصلاحيات:', 'مدير النظام'),
-                    _buildInfoRow('تاريخ آخر دخول:', DateTime.now().toString().split(' ')[0]),
-                    _buildInfoRow('حالة الحساب:', 'نشط'),
                   ],
                 ),
               ),
             ),
-            
-            const SizedBox(height: 20),
-            
-            // قائمة الإعدادات
-            const Text(
-              'إدارة الحسابات',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 12),
-            
-            _buildOptionCard(
-              'تغيير كلمة المرور',
-              'تحديث كلمة مرور الحساب الحالي',
-              Icons.lock,
-              Colors.orange,
-              () => _showChangePasswordDialog(context),
-            ),
-            
-            _buildOptionCard(
-              'إعدادات الأمان',
-              'تفعيل المصادقة الثنائية والأمان',
-              Icons.security,
-              Colors.red,
-              () => _showSecurityDialog(context),
-            ),
-            
-            _buildOptionCard(
-              'إضافة مستخدم جديد',
-              'إنشاء حساب مستخدم جديد للنظام',
-              Icons.person_add,
-              Colors.green,
-              () => _showAddUserDialog(context),
-            ),
-            
-            _buildOptionCard(
-              'إدارة الصلاحيات',
-              'تحديد صلاحيات المستخدمين',
-              Icons.admin_panel_settings,
-              Colors.blue,
-              () => _showPermissionsDialog(context),
-            ),
-            
-            const Spacer(),
-            
-            // تحذير
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.amber.withOpacity(0.1),
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.amber),
-              ),
-              child: const Row(
-                children: [
-                  Icon(Icons.warning, color: Colors.amber),
-                  SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      'إدارة المستخدمين تتطلب صلاحيات إدارية عالية. تأكد من تأمين بياناتك.',
-                      style: TextStyle(fontSize: 12),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildInfoRow(String label, String value) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Row(
-        children: [
-          SizedBox(
-            width: 120,
-            child: Text(
-              label,
-              style: const TextStyle(fontWeight: FontWeight.bold, color: Colors.grey),
-            ),
-          ),
-          Expanded(child: Text(value)),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildOptionCard(
-    String title,
-    String subtitle,
-    IconData icon,
-    Color color,
-    VoidCallback onTap,
-  ) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 8),
-      child: ListTile(
-        leading: CircleAvatar(
-          backgroundColor: color.withOpacity(0.2),
-          child: Icon(icon, color: color),
-        ),
-        title: Text(title),
-        subtitle: Text(subtitle),
-        trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-        onTap: onTap,
-      ),
-    );
-  }
-
-  void _showChangePasswordDialog(BuildContext context) {
-    final currentPasswordController = TextEditingController();
-    final newPasswordController = TextEditingController();
-    final confirmPasswordController = TextEditingController();
-
-    showDialog(
-      context: context,
-      builder: (context) => Directionality(
-        textDirection: TextDirection.rtl,
-        child: AlertDialog(
-          title: const Text('تغيير كلمة المرور'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                controller: currentPasswordController,
-                obscureText: true,
-                decoration: const InputDecoration(
-                  labelText: 'كلمة المرور الحالية',
-                  border: OutlineInputBorder(),
+            const SizedBox(height: 16),
+            if (!isAdmin) ...[
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.amber.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.amber),
+                ),
+                child: const Row(
+                  children: [
+                    Icon(Icons.lock, color: Colors.amber),
+                    SizedBox(width: 8),
+                    Expanded(child: Text('هذه الصفحة مخصصة للمسؤول فقط')),
+                  ],
                 ),
               ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: newPasswordController,
-                obscureText: true,
-                decoration: const InputDecoration(
-                  labelText: 'كلمة المرور الجديدة',
-                  border: OutlineInputBorder(),
-                ),
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: confirmPasswordController,
-                obscureText: true,
-                decoration: const InputDecoration(
-                  labelText: 'تأكيد كلمة المرور',
-                  border: OutlineInputBorder(),
-                ),
-              ),
+            ] else ...[
+              const Text('صلاحيات المستخدمين', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              const UserPermissionsCard(username: 'admin', displayName: 'المدير (admin)'),
+              const UserPermissionsCard(username: 'mohammed', displayName: 'محمد (mohammed)'),
+              const UserPermissionsCard(username: 'ahmed', displayName: 'أحمد (ahmed)'),
             ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('إلغاء'),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('تم تغيير كلمة المرور (قيد التطوير)')),
-                );
-              },
-              child: const Text('تحديث'),
-            ),
           ],
         ),
       ),
     );
   }
+}
 
-  void _showSecurityDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('إعدادات الأمان'),
-        content: const Column(
-          mainAxisSize: MainAxisSize.min,
+class UserPermissionsCard extends ConsumerStatefulWidget {
+  const UserPermissionsCard({super.key, required this.username, required this.displayName});
+  final String username;
+  final String displayName;
+
+  @override
+  ConsumerState<UserPermissionsCard> createState() => _UserPermissionsCardState();
+}
+
+class _UserPermissionsCardState extends ConsumerState<UserPermissionsCard> {
+  List<String> _perms = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final store = AuthLocalStore();
+    final p = await store.getPermissions(widget.username);
+    setState(() {
+      _perms = List<String>.from(p);
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isAdminUser = widget.username == 'admin';
+    final allKeys = AuthLocalStore.permissionKeys;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            ListTile(
-              leading: Icon(Icons.fingerprint),
-              title: Text('المصادقة البيومترية'),
-              trailing: Switch(value: false, onChanged: null),
-            ),
-            ListTile(
-              leading: Icon(Icons.lock_clock),
-              title: Text('انتهاء الجلسة التلقائي'),
-              subtitle: Text('30 دقيقة'),
-            ),
-            ListTile(
-              leading: Icon(Icons.shield),
-              title: Text('المصادقة الثنائية'),
-              trailing: Switch(value: false, onChanged: null),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('إغلاق'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showAddUserDialog(BuildContext context) {
-    final usernameController = TextEditingController();
-    final passwordController = TextEditingController();
-    String role = 'موظف';
-
-    showDialog(
-      context: context,
-      builder: (context) => Directionality(
-        textDirection: TextDirection.rtl,
-        child: StatefulBuilder(
-          builder: (context, setState) => AlertDialog(
-            title: const Text('إضافة مستخدم جديد'),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
+            Row(
               children: [
-                TextField(
-                  controller: usernameController,
-                  decoration: const InputDecoration(
-                    labelText: 'اسم المستخدم',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-                const SizedBox(height: 12),
-                TextField(
-                  controller: passwordController,
-                  obscureText: true,
-                  decoration: const InputDecoration(
-                    labelText: 'كلمة المرور',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-                const SizedBox(height: 12),
-                DropdownButtonFormField<String>(
-                  value: role,
-                  decoration: const InputDecoration(
-                    labelText: 'الصلاحيات',
-                    border: OutlineInputBorder(),
-                  ),
-                  items: const [
-                    DropdownMenuItem(value: 'مدير', child: Text('مدير النظام')),
-                    DropdownMenuItem(value: 'موظف', child: Text('موظف')),
-                    DropdownMenuItem(value: 'مشرف', child: Text('مشرف')),
-                  ],
-                  onChanged: (value) => setState(() => role = value ?? role),
-                ),
+                const Icon(Icons.person),
+                const SizedBox(width: 8),
+                Text(widget.displayName, style: const TextStyle(fontWeight: FontWeight.bold)),
+                const Spacer(),
+                if (isAdminUser)
+                  const Chip(label: Text('جميع الصلاحيات')),
               ],
             ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: const Text('إلغاء'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.pop(context);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('تم إضافة المستخدم (قيد التطوير)')),
+            const SizedBox(height: 8),
+            if (_loading)
+              const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: CircularProgressIndicator(),
+              )
+            else ...[
+              Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                children: allKeys.map((k) {
+                  final checked = isAdminUser ? true : _perms.contains(k);
+                  return FilterChip(
+                    label: Text(_permLabel(k)),
+                    selected: checked,
+                    onSelected: isAdminUser
+                        ? null
+                        : (v) async {
+                            setState(() {
+                              if (v) {
+                                _perms.add(k);
+                              } else {
+                                _perms.remove(k);
+                              }
+                            });
+                            await ref.read(authProvider.notifier).updateUserPermissions(widget.username, _perms);
+                          },
                   );
-                },
-                child: const Text('إضافة'),
+                }).toList(),
               ),
+              if (!isAdminUser)
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton.icon(
+                    onPressed: () async {
+                      setState(() => _perms = []);
+                      await ref.read(authProvider.notifier).updateUserPermissions(widget.username, _perms);
+                    },
+                    icon: const Icon(Icons.clear),
+                    label: const Text('إزالة جميع الصلاحيات'),
+                  ),
+                ),
             ],
-          ),
+          ],
         ),
       ),
     );
   }
 
-  void _showPermissionsDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('إدارة الصلاحيات'),
-        content: const Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text('صلاحيات النظام:', style: TextStyle(fontWeight: FontWeight.bold)),
-            SizedBox(height: 8),
-            ListTile(
-              leading: Icon(Icons.hotel),
-              title: Text('إدارة الغرف'),
-              trailing: Icon(Icons.check, color: Colors.green),
-            ),
-            ListTile(
-              leading: Icon(Icons.assignment),
-              title: Text('إدارة الحجوزات'),
-              trailing: Icon(Icons.check, color: Colors.green),
-            ),
-            ListTile(
-              leading: Icon(Icons.people),
-              title: Text('إدارة الموظفين'),
-              trailing: Icon(Icons.check, color: Colors.green),
-            ),
-            ListTile(
-              leading: Icon(Icons.assessment),
-              title: Text('عرض التقارير'),
-              trailing: Icon(Icons.check, color: Colors.green),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('إغلاق'),
-          ),
-        ],
-      ),
-    );
+  String _permLabel(String key) {
+    switch (key) {
+      case 'dashboard':
+        return 'لوحة التحكم';
+      case 'rooms':
+        return 'الغرف';
+      case 'bookings':
+        return 'الحجوزات';
+      case 'payments':
+        return 'المدفوعات';
+      case 'employees':
+        return 'الموظفون';
+      case 'expenses':
+        return 'المصروفات';
+      case 'finance':
+        return 'المالية';
+      case 'reports':
+        return 'التقارير';
+      case 'notes':
+        return 'الملاحظات';
+      case 'settings':
+        return 'الإعدادات';
+      default:
+        return key;
+    }
   }
 }

--- a/mobile/lib/services/auth_local_store.dart
+++ b/mobile/lib/services/auth_local_store.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AuthLocalStore {
+  static const _kCurrentUser = 'current_user';
+  static const _kPermissionsMap = 'user_permissions';
+
+  static const List<String> permissionKeys = [
+    'dashboard',
+    'rooms',
+    'bookings',
+    'payments',
+    'employees',
+    'expenses',
+    'finance',
+    'reports',
+    'notes',
+    'settings',
+  ];
+
+  static const Map<String, Map<String, dynamic>> _fixedAccounts = {
+    'admin': {
+      'password': 'admin',
+      'user_type': 'admin',
+      'full_name': 'مدير النظام',
+      'id': 1,
+    },
+    'mohammed': {
+      'password': '1111',
+      'user_type': 'supervisor',
+      'full_name': 'محمد',
+      'id': 2,
+    },
+    'ahmed': {
+      'password': '2222',
+      'user_type': 'employee',
+      'full_name': 'أحمد',
+      'id': 3,
+    },
+  };
+
+  Future<Map<String, dynamic>?> validateCredentials(String username, String password) async {
+    final user = _fixedAccounts[username.trim()];
+    if (user == null) return null;
+    if (user['password'] != password) return null;
+
+    final perms = await getPermissions(username);
+    if (username == 'admin') {
+      return {
+        'id': user['id'],
+        'username': username,
+        'full_name': user['full_name'],
+        'user_type': user['user_type'],
+        'permissions': ['all'],
+      };
+    }
+    return {
+      'id': user['id'],
+      'username': username,
+      'full_name': user['full_name'],
+      'user_type': user['user_type'],
+      'permissions': perms,
+    };
+  }
+
+  Future<void> saveCurrentUser(Map<String, dynamic> userJson) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kCurrentUser, jsonEncode(userJson));
+  }
+
+  Future<Map<String, dynamic>?> loadCurrentUser() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_kCurrentUser);
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final json = jsonDecode(raw);
+      if (json is Map<String, dynamic>) return json;
+      if (json is Map) return json.map((key, value) => MapEntry(key.toString(), value));
+      return null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> clearSession() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_kCurrentUser);
+  }
+
+  Future<List<String>> getPermissions(String username) async {
+    if (username == 'admin') return ['all'];
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_kPermissionsMap);
+    if (raw == null) return <String>[];
+    try {
+      final map = jsonDecode(raw);
+      if (map is Map) {
+        final v = map[username];
+        if (v is List) {
+          return v.map((e) => e.toString()).toList();
+        }
+      }
+      return <String>[];
+    } catch (_) {
+      return <String>[];
+    }
+  }
+
+  Future<void> setPermissions(String username, List<String> permissions) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_kPermissionsMap);
+    Map<String, dynamic> map = {};
+    if (raw != null) {
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is Map) {
+          map = decoded.map((k, v) => MapEntry(k.toString(), v));
+        }
+      } catch (_) {}
+    }
+    map[username] = permissions;
+    await prefs.setString(_kPermissionsMap, jsonEncode(map));
+
+    // If updating admin, keep 'all'
+    if (username == 'admin') {
+      map[username] = ['all'];
+    }
+  }
+}

--- a/mobile/test/auth_login_test.dart
+++ b/mobile/test/auth_login_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:marina_hotel_mobile/providers/auth_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('نجاح تسجيل الدخول للمسؤول admin/admin', () async {
+    final notifier = AuthNotifier();
+    await notifier.login('admin', 'admin');
+    expect(notifier.state.isAuthenticated, true);
+    expect(notifier.state.currentUser?.username, 'admin');
+    expect(notifier.state.currentUser?.permissions.contains('all'), true);
+  });
+
+  test('فشل تسجيل الدخول لبيانات خاطئة', () async {
+    final notifier = AuthNotifier();
+    await notifier.login('admin', 'wrong');
+    expect(notifier.state.isAuthenticated, false);
+    expect(notifier.state.error, isNotNull);
+  });
+
+  test('mohammed يسجل دخول بدون صلاحيات افتراضيًا', () async {
+    final notifier = AuthNotifier();
+    await notifier.login('mohammed', '1111');
+    expect(notifier.state.isAuthenticated, true);
+    expect(notifier.state.currentUser?.username, 'mohammed');
+    expect(notifier.state.currentUser?.permissions.isEmpty, true);
+  });
+}

--- a/mobile/test/sidebar_permissions_test.dart
+++ b/mobile/test/sidebar_permissions_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:marina_hotel_mobile/components/admin_sidebar.dart';
+import 'package:marina_hotel_mobile/providers/auth_provider.dart';
+
+class FakeAuthNotifier extends AuthNotifier {
+  FakeAuthNotifier(AuthState state) : super() {
+    this.state = state;
+  }
+  @override
+  Future<void> restoreSession() async {}
+  @override
+  Future<void> login(String username, String password) async {}
+  @override
+  Future<void> logout() async {}
+}
+
+void main() {
+  testWidgets('إخفاء عنصر الغرف بدون صلاحية rooms', (tester) async {
+    final user = AuthUser(
+      id: 2,
+      username: 'mohammed',
+      fullName: 'محمد',
+      userType: 'supervisor',
+      permissions: const [],
+    );
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        authProvider.overrideWith((ref) => FakeAuthNotifier(AuthState(isAuthenticated: true, currentUser: user))),
+      ],
+      child: const Directionality(
+        textDirection: TextDirection.rtl,
+        child: MaterialApp(
+          home: Scaffold(
+            body: AdminSidebar(currentRoute: '/dashboard', onRouteSelected: _noop),
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.text('إدارة الغرف'), findsNothing);
+    expect(find.text('لوحة التحكم'), findsOneWidget);
+  });
+}
+
+void _noop(String _) {}


### PR DESCRIPTION
# Local auth + permission gating (Flutter mobile)

Summary:
- Adds Arabic RTL LoginScreen with username/password and toggle visibility
- Implements local accounts (admin, mohammed, ahmed) with role types and permission keys
- Persists session and per-user permissions in SharedPreferences; restores on app start
- Gates AdminSidebar items and screen actions by permissions (admin has all)
- Adds admin-only UI to manage user permissions (settings_users.dart)
- Blocks app until successful login; logout clears session and returns to login
- Basic tests for login success/failure and sidebar permission hiding

Details:
- New: lib/screens/auth/login_screen.dart
- New: lib/services/auth_local_store.dart with fixed accounts and storage helpers
- Updated: providers/auth_provider.dart to use local store, restore session, and persist
- Updated: main.dart with RootRouter splash/redirect logic; HomeShell enforces permissions
- Updated: components/admin_sidebar.dart to filter menu and add logout
- Updated: screens/rooms/rooms_list.dart to restrict add/edit by "rooms" permission
- Updated: screens/settings/settings_users.dart to allow admin to toggle permissions per user
- Tests: test/auth_login_test.dart, test/sidebar_permissions_test.dart

Permissions keys used: dashboard, rooms, bookings, payments, employees, expenses, finance, reports, notes, settings

Navigation:
- On login success: RootRouter shows HomeShell at /dashboard
- On logout: session cleared and RootRouter shows LoginScreen

Notes:
- All strings Arabic and RTL, theme uses Tajawal font per theme.dart


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ccaccb08-3b55-4b71-bc13-731d396a9ca5/task/4bb310fd-d56d-41d2-ada8-474d3ef8d87c))