### PR TITLE
Add SQLite backup format support

### DIFF
--- a/mobile/lib/providers/backup_provider.dart
+++ b/mobile/lib/providers/backup_provider.dart
@@ -164,7 +164,17 @@ class BackupStatusNotifier extends StateNotifier<BackupState> {
       final time = await _backupService.getAutoBackupTime();
       final enableLocal = await _localBackupService.isAutoLocalBackupEnabled();
       final localFreq = await _localBackupService.getAutoLocalBackupFrequency();
-      
+
+      final isAutoEnabled = autoEnabled || enableLocal;
+      final resolvedFrequency = autoEnabled ? frequency : localFreq;
+      final resolvedBackupType = enableLocal && autoEnabled
+          ? BackupType.both
+          : enableLocal
+              ? BackupType.local
+              : autoEnabled
+                  ? BackupType.googleDrive
+                  : BackupType.both;
+
       // التحقق من تسجيل الدخول في Google Drive
       GoogleSignInAccount? account;
       List<DriveBackupFile> driveBackups = [];
@@ -188,13 +198,12 @@ class BackupStatusNotifier extends StateNotifier<BackupState> {
         availableBackups: driveBackups,
         signedInAccount: account,
         autoSettings: AutoBackupSettings(
-          isEnabled: autoEnabled,
-          frequency: frequency,
+          isEnabled: isAutoEnabled,
+          frequency: resolvedFrequency,
           time: time,
           enableLocalBackup: enableLocal,
           enableGoogleDriveBackup: autoEnabled,
-          backupType: enableLocal && autoEnabled ? BackupType.both :
-                     enableLocal ? BackupType.local : BackupType.googleDrive,
+          backupType: resolvedBackupType,
         ),
       );
     } catch (e) {
@@ -387,13 +396,18 @@ class BackupStatusNotifier extends StateNotifier<BackupState> {
   /// تحديث إعدادات النسخ التلقائي
   Future<void> updateAutoBackupSettings(AutoBackupSettings settings) async {
     try {
-      await _backupService.setAutoBackupEnabled(settings.isEnabled);
-      
-      if (settings.isEnabled) {
-        await _backupService.setAutoBackupFrequency(settings.frequency);
-        await _backupService.setAutoBackupTime(settings.time);
-        
-        // جدولة المهمة حسب التكرار
+      final enableDrive = settings.isEnabled && settings.enableGoogleDriveBackup;
+      final enableLocal = settings.isEnabled && settings.enableLocalBackup;
+      final shouldScheduleTask = enableDrive || enableLocal;
+
+      await _backupService.setAutoBackupEnabled(enableDrive);
+      await _backupService.setAutoBackupFrequency(settings.frequency);
+      await _backupService.setAutoBackupTime(settings.time);
+
+      await _localBackupService.setAutoLocalBackupEnabled(enableLocal);
+      await _localBackupService.setAutoLocalBackupFrequency(settings.frequency);
+
+      if (shouldScheduleTask) {
         switch (settings.frequency) {
           case 'daily':
             await AutoBackupTask.scheduleDaily(time: settings.time);
@@ -410,13 +424,27 @@ class BackupStatusNotifier extends StateNotifier<BackupState> {
               day: settings.day ?? 1,
             );
             break;
+          default:
+            await AutoBackupTask.scheduleDaily(time: settings.time);
+            break;
         }
       } else {
         await AutoBackupTask.cancelScheduled();
       }
 
+      final updatedBackupType = enableDrive && enableLocal
+          ? BackupType.both
+          : enableLocal
+              ? BackupType.local
+              : enableDrive
+                  ? BackupType.googleDrive
+                  : settings.backupType;
+
       state = state.copyWith(
-        autoSettings: settings,
+        autoSettings: settings.copyWith(
+          isEnabled: shouldScheduleTask,
+          backupType: updatedBackupType,
+        ),
         status: BackupStatus.success,
         message: 'تم تحديث إعدادات النسخ التلقائي',
       );

--- a/mobile/lib/screens/reports/debts_report_screen.dart
+++ b/mobile/lib/screens/reports/debts_report_screen.dart
@@ -559,7 +559,7 @@ class _DebtsReportScreenState extends ConsumerState<DebtsReportScreen> {
       return DateTime.parse(normalized);
     } catch (_) {
       final safeDate = Time.safeIsoToDateString(value);
-      return DateTime.parse('$safeDateT00:00:00');
+      return DateTime.parse('${safeDate}T00:00:00');
     }
   }
 }

--- a/mobile/lib/services/repositories/debts_repository.dart
+++ b/mobile/lib/services/repositories/debts_repository.dart
@@ -26,7 +26,7 @@ class DebtsRepository {
     String? pledgeType,
     String? note,
   }) {
-    final remaining = (totalAmount - paidAmount).clamp(0, double.infinity);
+    final remaining = (totalAmount - paidAmount).clamp(0, double.infinity).toDouble();
     return dao.insertOne(
       DebtsCompanion(
         bookingLocalId: d.Value(bookingLocalId),
@@ -63,7 +63,7 @@ class DebtsRepository {
     }
     final newTotal = totalAmount ?? existing.totalAmount;
     final newPaid = paidAmount ?? existing.paidAmount;
-    final remaining = (newTotal - newPaid).clamp(0, double.infinity);
+    final remaining = (newTotal - newPaid).clamp(0, double.infinity).toDouble();
     return dao.updateById(
       id,
       DebtsCompanion(


### PR DESCRIPTION
## Summary
- add a dedicated backup format enum and propagate metadata so SQLite archives are recognized alongside JSON
- implement local backup/export flows that generate and restore SQLite files, including metadata sidecars and import validation
- extend Google Drive integrations and UI to support selecting and displaying backup formats across manual and automatic workflows
- update automated backup scheduling to respect the chosen format for both local and cloud tasks

## Testing
- Not run (Flutter tooling unavailable in current environment)


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/880712a1-4e2b-4bda-939d-dea7944ef4dc/task/633a710d-1abd-4fa8-a503-4578964bd7e7))