### PR TITLE
Hotfix: Fix keystore path in key.properties

### DIFF
--- a/mobile/android/key.properties
+++ b/mobile/android/key.properties
@@ -2,7 +2,7 @@
 # This ensures consistent SHA-1 fingerprint across all build types
 # SHA-1: 67:12:57:A2:9B:53:FA:71:AC:BC:0F:A8:C9:54:2F:3F:46:0B:A8:1C
 
-storeFile=app/release.keystore
+storeFile=release.keystore
 storePassword=Marina2025SecureKey
 keyAlias=marina-hotel-app
 keyPassword=Marina2025SecureKey


### PR DESCRIPTION
Fix keystore path in key.properties

Fixes the build error that occurred during APK signing:
> Keystore file '/home/runner/work/marina-hotel-wit-app/marina-hotel-wit-app/mobile/android/app/app/release.keystore' not found for signing config 'unified'.

Changes:
- Changed `storeFile=app/release.keystore` to `storeFile=release.keystore`
- The path should be relative to the `android/app` directory where Gradle expects it
- This ensures the keystore is found at the correct location: `android/app/release.keystore`

This hotfix enables successful APK builds with the unified keystore approach and consistent SHA-1 fingerprint:
`67:12:57:A2:9B:53:FA:71:AC:BC:0F:A8:C9:54:2F:3F:46:0B:A8:1C`

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/d1d3322d-1fde-42ba-bce8-4d165b056b1b/task/40ae6533-27d1-4e8e-948d-72f1f403890b))