### PR TITLE
إصلاح أخطاء البناء في providers.dart - إضافة استيرادات مفقودة

### DIFF
--- a/mobile/lib/services/providers.dart
+++ b/mobile/lib/services/providers.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'local_db.dart';
 import 'repositories/rooms_repository.dart';
@@ -22,6 +23,7 @@ export '../providers/auto_backup_provider.dart';
 // إضافة Smart Sync Providers
 export '../providers/smart_sync_provider.dart';
 // إضافة Firestore Sync Providers
+import '../providers/firestore_sync_provider.dart';
 export '../providers/firestore_sync_provider.dart';
 
 final databaseProvider = Provider<AppDatabase>((ref) => DatabaseManager.instance);


### PR DESCRIPTION
## 🐛 إصلاح أخطاء البناء في providers.dart

### ملخص التغييرات
إصلاح خطأين في البناء كانا يمنعان نجاح GitHub Actions على الفرع الأساسي:

### التغييرات
- ✅ إضافة `import 'package:flutter/foundation.dart'` لحل خطأ `debugPrint` غير معرّف
- ✅ إضافة `import '../providers/firestore_sync_provider.dart'` لحل خطأ `firestoreSyncProvider` غير معرّف

### التفاصيل الفنية
**الملف المعدّل:** `mobile/lib/services/providers.dart`

**المشكلة الأولى:** 
- كان الكود يستخدم `debugPrint` في السطر 47 دون استيراد `flutter/foundation.dart`
- أدى هذا إلى خطأ: `Error: Method not found: 'debugPrint'`

**المشكلة الثانية:**
- كان الكود يستخدم `firestoreSyncProvider.notifier` في السطر 45 دون استيراد المزود
- Export وحده لا يكفي للاستخدام داخل نفس الملف
- أدى هذا إلى خطأ: `Error: Undefined name 'firestoreSyncProvider'`

### التأثير
- 🔧 **نوع التغيير:** إصلاح خطأ (Bug fix)
- 📦 **التأثير:** إصلاح حرج - كان يمنع البناء بالكامل
- ✅ **الاختبار:** تم التحقق من أن الاستيرادات الآن صحيحة ومتاحة

### الخلاصة
إضافة استيرادين مفقودين لحل أخطاء البناء في GitHub Actions وتمكين نجاح الكومبايلر.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/0b16609a-88d1-466d-b6ce-c98b494e97e8/task/bd5183e1-e50a-4a22-9448-3bf91b69e54c))