### PR TITLE
Fix: use expectedNights for active bookings; remove DateTime.now() from billing calculations

### DIFF
--- a/mobile/lib/screens/bookings/bookings_list.dart
+++ b/mobile/lib/screens/bookings/bookings_list.dart
@@ -106,9 +106,9 @@ class _BookingsListScreenState extends ConsumerState<BookingsListScreen> {
                           final expectedNights = booking.expectedNights > 0
                               ? booking.expectedNights
                               : (checkin == null ? 1 : Time.nightsWithCutoff(checkin, checkout: plannedCheckout));
-                          final actualNights = checkin == null
-                              ? expectedNights
-                              : Time.nightsWithCutoff(checkin, checkout: actualCheckout ?? plannedCheckout);
+                          final actualNights = actualCheckout != null && checkin != null
+                              ? Time.nightsWithCutoff(checkin, checkout: actualCheckout)
+                              : expectedNights;
                           final totalAmount = (actualNights * price).toDouble();
                           return _BookingRow(
                             index: index,
@@ -142,9 +142,9 @@ class _BookingsListScreenState extends ConsumerState<BookingsListScreen> {
                     final expectedNights = booking.expectedNights > 0
                         ? booking.expectedNights
                         : (checkin == null ? 1 : Time.nightsWithCutoff(checkin, checkout: plannedCheckout));
-                    final actualNights = checkin == null
-                        ? expectedNights
-                        : Time.nightsWithCutoff(checkin, checkout: actualCheckout ?? plannedCheckout);
+                    final actualNights = actualCheckout != null && checkin != null
+                        ? Time.nightsWithCutoff(checkin, checkout: actualCheckout)
+                        : expectedNights;
                     final totalAmount = (actualNights * price).toDouble();
                     return _BookingRow(
                       index: index + 1,

--- a/mobile/lib/screens/payments/booking_checkout_screen.dart
+++ b/mobile/lib/screens/payments/booking_checkout_screen.dart
@@ -38,8 +38,8 @@ class _BookingCheckoutScreenState extends ConsumerState<BookingCheckoutScreen> {
           final expectedNights = widget.booking.expectedNights > 0
               ? widget.booking.expectedNights
               : (checkin != null ? Time.nightsWithCutoff(checkin, checkout: plannedCheckout) : 1);
-          final actualNights = checkin != null
-              ? Time.nightsWithCutoff(checkin, checkout: actualCheckout ?? plannedCheckout)
+          final actualNights = actualCheckout != null && checkin != null
+              ? Time.nightsWithCutoff(checkin, checkout: actualCheckout)
               : expectedNights;
           
           // التكلفة الإجمالية = الليالي الفعلية × سعر الليلة

--- a/mobile/lib/screens/payments/booking_payment_screen.dart
+++ b/mobile/lib/screens/payments/booking_payment_screen.dart
@@ -142,7 +142,9 @@ class _BookingPaymentScreenState extends ConsumerState<BookingPaymentScreen>
           final expectedNights = widget.booking.expectedNights > 0
               ? widget.booking.expectedNights
               : Time.nightsWithCutoff(checkin, checkout: plannedCheckout);
-          final actualNights = Time.nightsWithCutoff(checkin, checkout: actualCheckout ?? plannedCheckout);
+          final actualNights = actualCheckout != null
+              ? Time.nightsWithCutoff(checkin, checkout: actualCheckout)
+              : expectedNights;
           
           // التكلفة الإجمالية = الليالي الفعلية × سعر الليلة (وليس المتوقعة)
           final totalAmount = actualNights * roomRate;
@@ -1323,7 +1325,7 @@ class _BookingPaymentScreenState extends ConsumerState<BookingPaymentScreen>
     final checkin = DateTime.tryParse(widget.booking.checkinDate) ?? DateTime.now();
     final plannedCheckout = widget.booking.checkoutDate != null ? DateTime.tryParse(widget.booking.checkoutDate!) : null;
     final actualCheckout = widget.booking.actualCheckout != null ? DateTime.tryParse(widget.booking.actualCheckout!) : null;
-    final checkout = actualCheckout ?? plannedCheckout ?? checkin;
+    final checkout = actualCheckout ?? plannedCheckout ?? checkin.add(Duration(days: widget.booking.expectedNights));
     final roomsRepo = ref.read(roomsRepoProvider);
     final room = await roomsRepo.watchByNumber(widget.booking.roomNumber).first;
     final invoice = Invoice(


### PR DESCRIPTION


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/f5acdcc1-b0d5-480e-b8a7-cf1893feae04/task/987a9318-04f9-4a31-9d18-5fedcf309ed2))