### PR TITLE
إصلاح: تحديث تلقائي لحساب المدفوعات بعد الاستعادة/المزامنة

### DIFF
--- a/mobile/lib/screens/payments/booking_payment_screen.dart
+++ b/mobile/lib/screens/payments/booking_payment_screen.dart
@@ -175,7 +175,7 @@ class _BookingPaymentScreenState extends ConsumerState<BookingPaymentScreen>
           final plannedCheckout = _resolvePlannedCheckout();
           final actualCheckout = widget.booking.actualCheckout != null ? DateTime.tryParse(widget.booking.actualCheckout!) : null;
           final expectedNights = _resolveExpectedNights(checkin, plannedCheckout);
-          final actualNights = Time.nightsWithCutoff(checkin, checkout: actualCheckout ?? plannedCheckout);
+          final actualNights = Time.nightsWithCutoff(checkin, checkout: actualCheckout ?? DateTime.now());
           
           // التكلفة الإجمالية = الليالي الفعلية × سعر الليلة (وليس المتوقعة)
           final totalAmount = actualNights * roomRate;

--- a/mobile/lib/services/restore_fix_service.dart
+++ b/mobile/lib/services/restore_fix_service.dart
@@ -190,10 +190,16 @@ class RestoreFixService {
             changes.addAll(bookingChanges);
           }
           
-          final paymentChanges = await _recalculateBookingFinancials(booking, fixId);
-          if (paymentChanges.isNotEmpty) {
-            paymentsChecked++;
-            changes.addAll(paymentChanges);
+          final updatedBooking = await (db.select(db.bookings)
+                ..where((b) => b.id.equals(booking.id)))
+              .getSingleOrNull();
+          
+          if (updatedBooking != null) {
+            final paymentChanges = await _recalculateBookingFinancials(updatedBooking, fixId);
+            if (paymentChanges.isNotEmpty) {
+              paymentsChecked++;
+              changes.addAll(paymentChanges);
+            }
           }
         }
         
@@ -270,21 +276,17 @@ class RestoreFixService {
     // استثناء الحجوزات المحذوفة
     query.where((b) => b.deletedAt.isNull());
     
-    // البحث عن الحجوزات النشطة أو المكتملة حديثاً
+    // البحث عن الحجوزات النشطة (لم تسجل مغادرة فعلية)
     query.where((b) => 
-      b.status.equals('محجوزة') |
-      b.status.equals('active') |
-      b.status.equals('confirmed') |
-      b.status.equals('checked_in')
+      (b.status.equals('محجوزة') |
+       b.status.equals('active') |
+       b.status.equals('confirmed') |
+       b.status.equals('checked_in')) &
+      b.actualCheckout.isNull()
     );
     
-    // التأكد من وجود تواريخ الدخول والخروج
-    query.where((b) => b.checkinDate.isNotNull() & b.checkoutDate.isNotNull());
-    
-    if (backupDate != null) {
-      final cutoff = backupDate.millisecondsSinceEpoch ~/ 1000;
-      query.where((b) => b.updatedAt.isBiggerOrEqualValue(cutoff));
-    }
+    // التأكد من وجود تاريخ الدخول
+    query.where((b) => b.checkinDate.isNotNull());
     
     return await query.get();
   }
@@ -298,7 +300,7 @@ class RestoreFixService {
       final checkinDate = DateTime.parse(booking.checkinDate);
       final checkoutDate = booking.actualCheckout != null 
           ? DateTime.parse(booking.actualCheckout!)
-          : DateTime.parse(booking.checkoutDate!);
+          : now;
       
       // حساب الليالي باستخدام قاعدة الساعة 14:00
       final calculatedNights = Time.nightsWithCutoff(checkinDate, checkout: checkoutDate);
@@ -371,6 +373,30 @@ class RestoreFixService {
       double? expectedTotal;
       if (room != null) {
         expectedTotal = booking.calculatedNights * room.price;
+        final remainingBalance = expectedTotal - totalPaid;
+        final isFullyPaid = remainingBalance <= 0;
+        
+        if (booking.totalDueCached != expectedTotal ||
+            booking.totalPaidCached != totalPaid ||
+            booking.remainingBalanceCached != remainingBalance ||
+            booking.isFullyPaid != isFullyPaid) {
+          await bookingsDao.updateById(
+            booking.id,
+            BookingsCompanion(
+              totalDueCached: Value(expectedTotal),
+              totalPaidCached: Value(totalPaid),
+              remainingBalanceCached: Value(remainingBalance),
+              isFullyPaid: Value(isFullyPaid),
+              updatedAt: Value(Time.nowEpoch()),
+              lastModified: Value(Time.nowEpoch()),
+            ),
+            originIsServer: false,
+          );
+          
+          changes.add('تحديث المبالغ المخزنة للحجز #${booking.id}: الإجمالي=${expectedTotal.toStringAsFixed(2)}, المدفوع=${totalPaid.toStringAsFixed(2)}, المتبقي=${remainingBalance.toStringAsFixed(2)}');
+          debugPrint('💰 ${changes.last}');
+        }
+        
         if ((totalPaid - expectedTotal).abs() > 0.01) {
           await _logChange(
             fixId: fixId,


### PR DESCRIPTION
- تحديث حساب الليالي الفعلية في شاشة المدفوعات باستخدام DateTime.now()
- تحسين RestoreFixService لإعادة حساب المبالغ تلقائياً بعد الاستعادة
- إضافة تحديث القيم المخزنة (totalDueCached, totalPaidCached, remainingBalanceCached)
- معالجة الحجوزات النشطة فقط (بدون actualCheckout)
- دعم المزامنة عبر أجهزة متعددة مع فارق أيام

الآن عند استعادة نسخة احتياطية قديمة أو مزامنة من جهاز آخر، يتم إعادة حساب جميع المبالغ تلقائياً حسب الوقت الحالي مع قاعدة 14:00