### PR TITLE
Capy jam: cap-1-73d867df remove sync queue attempt limits

### DIFF
--- a/mobile/lib/services/sync_queue_service.dart
+++ b/mobile/lib/services/sync_queue_service.dart
@@ -44,7 +44,6 @@ class SyncQueueService {
   SyncQueueService._();
   
   static const String _queueKey = 'sync_queue_items';
-  static const int _maxAttempts = 5;
   static const Duration _retryInterval = Duration(minutes: 2);
   
   Timer? _processingTimer;
@@ -145,43 +144,25 @@ class SyncQueueService {
     try {
       debugPrint('🔄 [SyncQueue] معالجة ${items.length} عنصر...');
       
-      final itemsToRemove = <String>[];
-      final itemsToUpdate = <SyncQueueItem>[];
-      
-      for (final item in items) {
-        if (item.attempts >= _maxAttempts) {
-          debugPrint('⚠️ [SyncQueue] تجاوز الحد الأقصى للمحاولات: ${item.id}');
-          itemsToRemove.add(item.id);
-        }
-      }
-      
-      for (final id in itemsToRemove) {
-        await removeFromQueue(id);
-      }
-      
-      final remainingItems = items.where((item) => !itemsToRemove.contains(item.id)).toList();
-      if (remainingItems.isEmpty) {
-        debugPrint('✓ [SyncQueue] لا توجد عناصر متبقية للمعالجة');
-        return;
-      }
+      final itemsToProcess = List<SyncQueueItem>.from(items);
       
       try {
         final success = await SmartSyncManager.instance.pushLocalChanges();
         
         if (success) {
-          for (final item in remainingItems) {
+          for (final item in itemsToProcess) {
             await removeFromQueue(item.id);
           }
-          debugPrint('✅ [SyncQueue] تم رفع جميع العناصر بنجاح (${remainingItems.length} عنصر)');
+          debugPrint('✅ [SyncQueue] تم رفع جميع العناصر بنجاح (${itemsToProcess.length} عنصر)');
         } else {
-          for (final item in remainingItems) {
+          for (final item in itemsToProcess) {
             item.attempts++;
             await updateQueueItem(item);
           }
-          debugPrint('⚠️ [SyncQueue] فشل الرفع - تحديث محاولات ${remainingItems.length} عنصر');
+          debugPrint('⚠️ [SyncQueue] فشل الرفع - تحديث محاولات ${itemsToProcess.length} عنصر');
         }
       } catch (e) {
-        for (final item in remainingItems) {
+        for (final item in itemsToProcess) {
           item.attempts++;
           await updateQueueItem(item);
         }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove attempt limit enforcement from sync queue processing

- Simplify queue item filtering logic by eliminating max attempts check

- Refactor item processing to use direct list copy instead of conditional filtering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SyncQueueService"] -->|Remove _maxAttempts constant| B["Simplified Processing"]
  B -->|Eliminate attempt limit check| C["Process all items"]
  C -->|Update item attempts on failure| D["Retry mechanism"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync_queue_service.dart</strong><dd><code>Remove attempt limits and simplify queue processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/sync_queue_service.dart

<ul><li>Removed <code>_maxAttempts</code> constant (previously set to 5)<br> <li> Eliminated attempt limit validation logic that removed items exceeding <br>max attempts<br> <li> Simplified item processing by using direct list copy instead of <br>filtering based on attempt count<br> <li> Refactored variable names from <code>remainingItems</code> to <code>itemsToProcess</code> for <br>clarity<br> <li> Removed intermediate lists (<code>itemsToRemove</code>, <code>itemsToUpdate</code>) used for <br>filtering</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/259/files#diff-d4e8f266c875023a26f023f729c339481a4f1667ba50558abc5bb941593338e1">+6/-25</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

