### PR TITLE
Fix missing start() declaration in auto sync engine

### DIFF
--- a/mobile/lib/services/google_drive_auto_sync_engine.dart
+++ b/mobile/lib/services/google_drive_auto_sync_engine.dart
@@ -184,6 +184,7 @@ class AutoSyncEngine with WidgetsBindingObserver {
     _emitState();
   }
 
+  Future<void> start() async {
     final canStart = await SyncLocks.autoEngineLock.synchronized(() async {
       if (!_isInitialized) return _StartResult.notInitialized;
       if (_isRunning) return _StartResult.alreadyRunning;


### PR DESCRIPTION
### **User description**
## Summary
- add the missing start() method declaration in 
- keep the surrounding logic unchanged so the auto-sync engine compiles and can start correctly

## Testing
- not run (Flutter tooling unavailable in this environment)


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing `start()` method declaration in auto sync engine

- Enables proper compilation and initialization of auto-sync functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AutoSyncEngine class"] -- "missing start() method" --> B["Compilation error"]
  C["Add Future&lt;void&gt; start() declaration"] -- "fixes" --> B
  B -- "resolved" --> D["Engine can start correctly"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google_drive_auto_sync_engine.dart</strong><dd><code>Add missing start() method declaration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/google_drive_auto_sync_engine.dart

<ul><li>Add missing <code>Future<void> start()</code> async method declaration<br> <li> Method contains existing sync lock logic and initialization checks<br> <li> Enables auto-sync engine to compile and start properly</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/266/files#diff-6ed93b022b521ae310aafbb48bf2a158ab034da14e9b006e0df5769df5a06e50">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

