### PR TITLE
Fix Map type casting and FK constraint failures in sync

### DIFF
--- a/mobile/lib/data/sync_models.dart
+++ b/mobile/lib/data/sync_models.dart
@@ -111,8 +111,10 @@ class SyncSnapshot {
           .toList();
       parsedTables[entry.key] = list;
     }
+    final metadataSource = json['metadata'];
+    final metadataJson = metadataSource is Map ? Map<String, dynamic>.from(metadataSource) : <String, dynamic>{};
     return SyncSnapshot(
-      metadata: SyncMetadata.fromJson(json['metadata'] as Map<String, dynamic>? ?? {}),
+      metadata: SyncMetadata.fromJson(metadataJson),
       tables: parsedTables,
     );
   }

--- a/mobile/lib/services/auto_backup_manager.dart
+++ b/mobile/lib/services/auto_backup_manager.dart
@@ -191,12 +191,22 @@ class AutoBackupManager {
       final backupData = await _backupService!.exportDatabaseToJson();
       
       // تحديث البيانات الوصفية لتمييز النسخة التلقائية
-      final metadata = backupData['metadata'] as Map<String, dynamic>;
+      final existingMetadata = backupData['metadata'];
+      Map<String, dynamic> metadata;
+      if (existingMetadata is Map<String, dynamic>) {
+        metadata = existingMetadata;
+      } else if (existingMetadata is Map) {
+        metadata = Map<String, dynamic>.from(existingMetadata);
+        backupData['metadata'] = metadata;
+      } else {
+        metadata = <String, dynamic>{};
+        backupData['metadata'] = metadata;
+      }
       metadata['backup_type'] = 'auto';
       metadata['trigger_reason'] = reason;
       metadata['changes_count'] = changesCount;
       metadata['device_info'] = '${Platform.operatingSystem} (تلقائي)';
-      metadata['device_id'] = _deviceId; // معرف الجهاز للمزامنة الذكية
+      metadata['device_id'] = _deviceId;
       metadata['created_by_device'] = _deviceId;
       
       // رفع النسخة الاحتياطية كملف تلقائي

--- a/mobile/lib/services/file_management_service.dart
+++ b/mobile/lib/services/file_management_service.dart
@@ -415,9 +415,12 @@ class FileManagementService {
           
           // تحديث metadata
           if (backupData.containsKey('metadata')) {
-            final metadata = BackupMetadata.fromJson(backupData['metadata']);
-            if (latestMetadata == null || metadata.backupTimestamp.isAfter(latestMetadata.backupTimestamp)) {
-              latestMetadata = metadata;
+            final metadataSource = backupData['metadata'];
+            if (metadataSource is Map) {
+              final metadata = BackupMetadata.fromJson(Map<String, dynamic>.from(metadataSource));
+              if (latestMetadata == null || metadata.backupTimestamp.isAfter(latestMetadata.backupTimestamp)) {
+                latestMetadata = metadata;
+              }
             }
           }
         } catch (e) {

--- a/mobile/lib/services/google_drive_backup_service.dart
+++ b/mobile/lib/services/google_drive_backup_service.dart
@@ -468,7 +468,8 @@ class GoogleDriveBackupService {
         final timestamp = DateTime.now();
         
         // تحديد البادئة والنوع حسب نوع النسخة
-        final metadata = backupData['metadata'] as Map<String, dynamic>? ?? {};
+        final rawMetadata = backupData['metadata'];
+        final metadata = rawMetadata is Map ? Map<String, dynamic>.from(rawMetadata) : <String, dynamic>{};
         final backupType = metadata['backup_type'] as String?;
         final syncType = metadata['sync_type'] as String?;
         
@@ -683,7 +684,11 @@ class GoogleDriveBackupService {
         throw Exception('النسخة الاحتياطية لا تحتوي على بيانات وصفية');
       }
 
-      final metadata = BackupMetadata.fromJson(backupData['metadata']);
+      final metadataJson = backupData['metadata'];
+      if (metadataJson is! Map) {
+        throw Exception('صيغة بيانات النسخة الاحتياطية غير صالحة');
+      }
+      final metadata = BackupMetadata.fromJson(Map<String, dynamic>.from(metadataJson));
       _logger.info('بدء استعادة نسخة بتاريخ ${metadata.backupTimestamp.toIso8601String()} تحتوي ${metadata.totalRecords} سجل', tag: 'RESTORE');
 
       if (metadata.databaseVersion > 3) {
@@ -692,27 +697,32 @@ class GoogleDriveBackupService {
 
       _log('🔄 بدء استعادة البيانات...');
 
-      await db.delete(db.rooms).go();
-      await db.delete(db.bookings).go();
-      await db.delete(db.bookingNotes).go();
-      await db.delete(db.bookingNights).go();
-      await db.delete(db.hotelDayLedger).go();
-      await db.delete(db.shiftNotes).go();
-      await db.delete(db.employees).go();
-      await db.delete(db.expenses).go();
-      await db.delete(db.cashTransactions).go();
-      await db.delete(db.payments).go();
-      await db.delete(db.debts).go();
-      await db.delete(db.autoFixRuns).go();
-      await db.delete(db.integrityViolations).go();
-      await db.delete(db.appSessions).go();
-      await db.delete(db.salaryCycles).go();
-      await db.delete(db.salaryPayments).go();
-      await db.delete(db.restoreFixLog).go();
-      await db.delete(db.syncQueue).go();
-      await db.delete(db.syncLog).go();
-      await db.delete(db.syncConflicts).go();
-      await db.delete(db.syncState).go();
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+      try {
+        await db.delete(db.rooms).go();
+        await db.delete(db.bookings).go();
+        await db.delete(db.bookingNotes).go();
+        await db.delete(db.bookingNights).go();
+        await db.delete(db.hotelDayLedger).go();
+        await db.delete(db.shiftNotes).go();
+        await db.delete(db.employees).go();
+        await db.delete(db.expenses).go();
+        await db.delete(db.cashTransactions).go();
+        await db.delete(db.payments).go();
+        await db.delete(db.debts).go();
+        await db.delete(db.autoFixRuns).go();
+        await db.delete(db.integrityViolations).go();
+        await db.delete(db.appSessions).go();
+        await db.delete(db.salaryCycles).go();
+        await db.delete(db.salaryPayments).go();
+        await db.delete(db.restoreFixLog).go();
+        await db.delete(db.syncQueue).go();
+        await db.delete(db.syncLog).go();
+        await db.delete(db.syncConflicts).go();
+        await db.delete(db.syncState).go();
+      } finally {
+        await db.customStatement('PRAGMA foreign_keys = ON');
+      }
 
       if (backupData.containsKey('rooms')) {
         final roomsData = backupData['rooms'] as List<dynamic>;
@@ -904,7 +914,11 @@ class GoogleDriveBackupService {
       if (backupData.containsKey('system_settings')) {
         _log('⚙️ تطبيق إعدادات النظام من النسخة الاحتياطية...');
         try {
-          final settings = backupData['system_settings'] as Map<String, dynamic>;
+          final rawSettings = backupData['system_settings'];
+          if (rawSettings is! Map) {
+            throw Exception('صيغة إعدادات النظام غير صالحة');
+          }
+          final settings = Map<String, dynamic>.from(rawSettings);
           final prefs = await SharedPreferences.getInstance();
           
           final keys = SystemSettingKeys.all;

--- a/mobile/lib/services/google_drive_unified_sync_coordinator.dart
+++ b/mobile/lib/services/google_drive_unified_sync_coordinator.dart
@@ -652,8 +652,10 @@ class GoogleDriveUnifiedSyncCoordinator {
     try {
       final backupData = await _backupService!.exportDatabaseToJson();
       
+      final metadata = backupData['metadata'];
+      final baseMetadata = metadata is Map ? Map<String, dynamic>.from(metadata) : <String, dynamic>{};
       backupData['metadata'] = {
-        ...backupData['metadata'],
+        ...baseMetadata,
         'backup_type': 'full',
         'sync_type': 'scheduled',
         'device_id': _deltaSync!.deviceId,

--- a/mobile/lib/services/local_backup_service.dart
+++ b/mobile/lib/services/local_backup_service.dart
@@ -339,7 +339,10 @@ class LocalBackupService {
             final content = await file.readAsString();
             final jsonData = jsonDecode(content) as Map<String, dynamic>;
             if (jsonData.containsKey('metadata')) {
-              metadata = BackupMetadata.fromJson(jsonData['metadata']);
+              final metadataSource = jsonData['metadata'];
+              if (metadataSource is Map) {
+                metadata = BackupMetadata.fromJson(Map<String, dynamic>.from(metadataSource));
+              }
             }
           } else {
             final metadataFile = File(_metadataFilePath(file.path));
@@ -409,7 +412,11 @@ class LocalBackupService {
       throw Exception('النسخة الاحتياطية لا تحتوي على بيانات وصفية');
     }
 
-    final metadata = BackupMetadata.fromJson(backupData['metadata']);
+    final metadataSource = backupData['metadata'];
+    if (metadataSource is! Map) {
+      throw Exception('صيغة بيانات النسخة الاحتياطية غير صالحة');
+    }
+    final metadata = BackupMetadata.fromJson(Map<String, dynamic>.from(metadataSource));
     if (metadata.databaseVersion > AppDatabase().schemaVersion) {
       throw Exception('إصدار قاعدة البيانات في النسخة الاحتياطية أحدث من التطبيق الحالي');
     }
@@ -417,14 +424,19 @@ class LocalBackupService {
     debugPrint('🔄 بدء استعادة البيانات من نسخة JSON...');
     final db = getDatabase();
 
-    await db.delete(db.rooms).go();
-    await db.delete(db.bookings).go();
-    await db.delete(db.bookingNotes).go();
-    await db.delete(db.employees).go();
-    await db.delete(db.expenses).go();
-    await db.delete(db.cashTransactions).go();
-    await db.delete(db.payments).go();
-    await db.delete(db.syncState).go();
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    try {
+      await db.delete(db.rooms).go();
+      await db.delete(db.bookings).go();
+      await db.delete(db.bookingNotes).go();
+      await db.delete(db.employees).go();
+      await db.delete(db.expenses).go();
+      await db.delete(db.cashTransactions).go();
+      await db.delete(db.payments).go();
+      await db.delete(db.syncState).go();
+    } finally {
+      await db.customStatement('PRAGMA foreign_keys = ON');
+    }
 
     Future<void> insertList<T>(String key, Future<void> Function(Map<String, dynamic> json) insert) async {
       if (!backupData.containsKey(key)) {

--- a/mobile/lib/services/smart_google_drive_sync.dart
+++ b/mobile/lib/services/smart_google_drive_sync.dart
@@ -238,8 +238,10 @@ class SmartGoogleDriveSync {
       final backupData = await _driveService!.exportDatabaseToJson();
       
       // إضافة metadata للتمييز
+      final metadata = backupData['metadata'];
+      final baseMetadata = metadata is Map ? Map<String, dynamic>.from(metadata) : <String, dynamic>{};
       backupData['metadata'] = {
-        ...backupData['metadata'],
+        ...baseMetadata,
         'backup_type': 'full',
         'sync_type': 'scheduled',
       };

--- a/mobile/lib/services/smart_sync_manager.dart
+++ b/mobile/lib/services/smart_sync_manager.dart
@@ -757,7 +757,17 @@ class SmartSyncManager {
       // Fallback: رفع النسخة الكاملة (للأمان)
       _log('📦 رفع النسخة الكاملة...');
       final backupData = await _backupService!.exportDatabaseToJson();
-      final metadata = backupData['metadata'] as Map<String, dynamic>;
+      final existingMetadata = backupData['metadata'];
+      Map<String, dynamic> metadata;
+      if (existingMetadata is Map<String, dynamic>) {
+        metadata = existingMetadata;
+      } else if (existingMetadata is Map) {
+        metadata = Map<String, dynamic>.from(existingMetadata);
+        backupData['metadata'] = metadata;
+      } else {
+        metadata = <String, dynamic>{};
+        backupData['metadata'] = metadata;
+      }
       metadata['device_id'] = _deviceId;
       metadata['sync_type'] = 'push';
       metadata['sync_timestamp'] = DateTime.now().toIso8601String();


### PR DESCRIPTION
### **User description**
## Overview
Resolved two critical sync failures blocking mobile app backups and restores:

1. **Map Type Casting Issue** (`_Map<dynamic, dynamic>` is not a subtype of `Map<String, dynamic>`)
   - Affected: `uploadBackup()`, `restoreFromBackup()`, metadata mutations across sync services
   - Root cause: `jsonDecode()` returns dynamic maps that fail unsafe casts when spread into strongly-typed operations
   - Fix: All metadata accesses now safely convert with `Map<String, dynamic>.from()` before reading or mutating

2. **SQLite Foreign Key Constraint Failures** (DELETE FROM rooms failure)
   - Affected: Full restore operations in Drive and local backup services
   - Root cause: Clearing tables while FK constraints are active prevents cascading deletes
   - Fix: Wrap destructive table clears with `PRAGMA foreign_keys = OFF/ON`, preserving FK safety for data inserts

## Changes
- **google_drive_backup_service.dart**: Safe metadata casting in `uploadBackup()`, `restoreFromBackup()`, and settings restoration
- **auto_backup_manager.dart**, **smart_sync_manager.dart**, **smart_google_drive_sync.dart**: Map validation in metadata mutations
- **google_drive_unified_sync_coordinator.dart**: Safe spread operator usage for metadata
- **local_backup_service.dart**: FK pragma wrapping and validated metadata reads
- **file_management_service.dart**: Type checking in backup merge/analysis
- **sync_models.dart**: Safe metadata deserialization in `SyncSnapshot.fromJson()`

All changes maintain backward compatibility and add clear error messages for malformed backups.

<a href="https://capy.ai/project/de8f7703-e716-4ed3-af7d-2fa13f74008a/task/52a4156a-a350-4c8b-8b53-4c9cff6c8139"><img alt="Review with Capy" src="https://capy.ai/review-with-capy.svg"></a>


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Map type casting failures in sync operations using safe conversion

- Disable foreign key constraints during table clears to prevent constraint violations

- Add type validation for metadata and settings deserialization across backup services

- Wrap destructive operations with PRAGMA foreign_keys OFF/ON for safe restoration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dynamic Map from jsonDecode"] -->|"Safe conversion with Map.from()"| B["Strongly-typed Map<String, dynamic>"]
  C["Table deletion with FK constraints"] -->|"Wrap with PRAGMA OFF/ON"| D["Safe cascading deletes"]
  E["Metadata deserialization"] -->|"Type validation + conversion"| F["Valid BackupMetadata objects"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync_models.dart</strong><dd><code>Safe metadata deserialization in SyncSnapshot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/data/sync_models.dart

<ul><li>Add safe metadata conversion in <code>SyncSnapshot.fromJson()</code> using <br><code>Map<String, dynamic>.from()</code><br> <li> Check if metadata source is a Map before casting to prevent type <br>errors<br> <li> Provide empty map fallback for missing or invalid metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/267/files#diff-035678bc9631adb190865cfcede7c2c8ec55214993305665c318c10849028863">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auto_backup_manager.dart</strong><dd><code>Type-safe metadata handling in backup export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/auto_backup_manager.dart

<ul><li>Replace unsafe cast of metadata with type-safe conditional conversion<br> <li> Handle three cases: already-typed Map, untyped Map, and missing <br>metadata<br> <li> Update backupData with converted metadata to maintain consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/267/files#diff-b628e3ae9a641eb91db7b65279a98be9d460a6f8c7db762bc7cdc63f6d95e92f">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>file_management_service.dart</strong><dd><code>Validate metadata type in backup analysis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/file_management_service.dart

<ul><li>Add type check before converting metadata source in backup merge <br>analysis<br> <li> Use <code>Map<String, dynamic>.from()</code> for safe metadata deserialization<br> <li> Prevent crashes when processing backups with malformed metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/267/files#diff-73f91db41bd6976e61f288227f225220bc0dfdb5edf00c8ef38afc3a638da03a">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>google_drive_backup_service.dart</strong><dd><code>Fix metadata casting and FK constraints in Drive sync</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/google_drive_backup_service.dart

<ul><li>Safe metadata conversion in <code>uploadBackup()</code> with type checking<br> <li> Add metadata validation in <code>restoreFromBackup()</code> with explicit type <br>checks<br> <li> Wrap all table deletion operations with <code>PRAGMA foreign_keys OFF/ON</code><br> <li> Validate system_settings format before applying during restore</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/267/files#diff-bc07c4fc152a49577bdce599cc50c9958b74880f3291ad9b004ee40a5dc8d7f2">+38/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>google_drive_unified_sync_coordinator.dart</strong><dd><code>Safe metadata spread in full backup operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/google_drive_unified_sync_coordinator.dart

<ul><li>Safe metadata extraction and conversion before spread operator usage<br> <li> Prevent type casting errors when merging backup metadata<br> <li> Provide empty map fallback for missing metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/267/files#diff-d71efe8204fc328b92c45c99633c8b9264601d6e67b195ef67386fec0402ec08">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>local_backup_service.dart</strong><dd><code>Type-safe metadata and FK constraint handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/local_backup_service.dart

<ul><li>Add type validation for metadata in <code>getBackupMetadata()</code> method<br> <li> Wrap table deletion with <code>PRAGMA foreign_keys OFF/ON</code> in <br><code>restoreFromJson()</code><br> <li> Safe metadata conversion in both backup listing and restore operations</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/267/files#diff-e234d2271141bd41458051e459e5eeb3624bfb5b02648ea02fa51459e1d7efe5">+22/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>smart_google_drive_sync.dart</strong><dd><code>Safe metadata handling in full backup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/smart_google_drive_sync.dart

<ul><li>Safe metadata extraction and conversion before spread operator<br> <li> Handle untyped Map from backup data with fallback to empty map<br> <li> Prevent type casting errors in full backup metadata setup</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/267/files#diff-c20cc2c013e7a0ed318ff70586f76e849df707f5d6a1d186474bd58d1e1b6138">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>smart_sync_manager.dart</strong><dd><code>Type-safe metadata in fallback full backup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/smart_sync_manager.dart

<ul><li>Replace unsafe metadata cast with type-safe conditional conversion<br> <li> Handle three metadata source types: already-typed, untyped Map, and <br>missing<br> <li> Update backupData with converted metadata for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/267/files#diff-2c707d1a841a628a09779d5551466cfc1b0480d5f09510e037337cd5aa7bf6cc">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

