### PR TITLE
Mobile: stabilize sync triggers (Google Drive) + Appwrite assistant

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -31,6 +31,8 @@ import 'services/google_drive_backup_service.dart';
 import 'services/google_drive_logger.dart';
 import 'services/local_db.dart';
 import 'services/smart_sync_manager.dart';
+import 'services/appwrite_service.dart';
+import 'services/appwrite_sync_manager.dart';
 
 // AutoSync Engine imports
 import 'services/google_drive_auto_sync_engine.dart';
@@ -131,6 +133,8 @@ Future<void> _initializeFullyAutomatedSyncSystem() async {
     }
     
     await SyncQueueService.instance.initialize();
+
+    unawaited(_initializeAppwriteAssistant(database));
     
     _setupEngineMonitoring(autoSyncEngine);
     
@@ -153,6 +157,25 @@ Future<void> _initializeFullyAutomatedSyncSystem() async {
     debugPrint('Error: $e');
     debugPrint('Stack trace: $stackTrace');
     debugPrint('═══════════════════════════════════════════════════════');
+  }
+}
+
+Future<void> _initializeAppwriteAssistant(AppDatabase database) async {
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    final enabled = prefs.getBool('appwrite_sync_enabled') ?? true;
+    if (!enabled) {
+      return;
+    }
+
+    final intervalMinutes = prefs.getInt('appwrite_sync_interval') ?? 15;
+
+    final service = AppwriteService();
+    final manager = AppwriteSyncManager(appwriteService: service, database: database);
+    await manager.initialize();
+    manager.startAutoSync(interval: Duration(minutes: intervalMinutes));
+  } catch (e) {
+    debugPrint('⚠️ Appwrite assistant initialization failed: $e');
   }
 }
 

--- a/mobile/lib/services/daos/outbox_dao.dart
+++ b/mobile/lib/services/daos/outbox_dao.dart
@@ -1,9 +1,6 @@
-import 'dart:async';
 import 'dart:convert';
 import 'package:drift/drift.dart';
 import '../local_db.dart';
-import '../sync_guardian.dart';
-import '../google_drive_unified_sync_coordinator.dart';
 import '../google_drive_auto_sync_engine.dart';
 
 part 'outbox_dao.g.dart';
@@ -63,9 +60,8 @@ class OutboxDao extends DatabaseAccessor<AppDatabase> with _$OutboxDaoMixin {
             clientTs: Value(clientTs),
           ));
 
-    unawaited(SyncGuardian.instance.notifyLocalChange(table: entity, operation: op));
-    GoogleDriveUnifiedSyncCoordinator.instance.notifyLocalChange(table: entity, operation: op);
     AutoSyncEngine.instance.notifyDataChange(table: entity, operation: op);
+
     return result;
   }
 

--- a/mobile/lib/services/google_drive_auto_sync_engine.dart
+++ b/mobile/lib/services/google_drive_auto_sync_engine.dart
@@ -505,15 +505,19 @@ class AutoSyncEngine with WidgetsBindingObserver {
     Map<String, dynamic>? recordData,
   }) {
     if (!_isRunning) return;
-    
+
     SyncLocks.autoEngineLock.synchronized(() {
       _pendingChangesCount += count;
     });
-    
+
     _emitState();
-    
+
     _log('💾 Data change detected: $table/$operation (count=$count, total pending=$_pendingChangesCount)');
-    
+
+    if (!_isSignedIn || !_hasNetworkConnection) {
+      return;
+    }
+
     _coordinator!.notifyLocalChange(
       table: table,
       operation: operation,

--- a/mobile/lib/services/google_drive_unified_sync_coordinator.dart
+++ b/mobile/lib/services/google_drive_unified_sync_coordinator.dart
@@ -244,16 +244,8 @@ class GoogleDriveUnifiedSyncCoordinator {
       return;
     }
     
-    // مراقبة تغييرات outbox للمزامنة التلقائية
     _outboxSubscription?.cancel();
-    if (_pushEnabled && _database != null) {
-      _outboxSubscription = (_database!.select(_database!.outbox)).watch().listen((_) {
-        _log('📦 Detected change in outbox', level: LogLevel.debug);
-        notifyLocalChange();
-      });
-      _log('✅ Started outbox monitoring for auto-sync');
-    }
-    
+
     if (_pullEnabled) {
       _pullCheckTimer?.cancel();
       _pullCheckTimer = Timer.periodic(


### PR DESCRIPTION
### **User description**
Changes:\n- Make Outbox trigger only AutoSyncEngine (avoid duplicate sync triggers)\n- Disable outbox watcher in GoogleDriveUnifiedSyncCoordinator to prevent double-trigger\n- AutoSyncEngine avoids starting push when offline/not signed-in\n- Start AppwriteSyncManager auto sync as assistant (respects appwrite_sync_enabled/appwrite_sync_interval)\n\nFiles:\n- mobile/lib/services/daos/outbox_dao.dart\n- mobile/lib/services/google_drive_unified_sync_coordinator.dart\n- mobile/lib/services/google_drive_auto_sync_engine.dart\n- mobile/lib/main.dart\n\nNo secrets touched.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Stabilize sync triggers by removing duplicate outbox watchers

- AutoSyncEngine now validates network/sign-in before triggering push

- Initialize AppwriteSyncManager as background assistant with configurable interval

- Consolidate sync notifications to use only AutoSyncEngine


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Outbox DAO"] -->|notifyDataChange| B["AutoSyncEngine"]
  B -->|check network & sign-in| C["Coordinator"]
  C -->|trigger sync| D["Google Drive"]
  E["AppwriteService"] -->|initialize| F["AppwriteSyncManager"]
  F -->|auto sync| G["Appwrite Backend"]
  H["SharedPreferences"] -->|config| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.dart</strong><dd><code>Initialize Appwrite sync manager as background assistant</code>&nbsp; </dd></summary>
<hr>

mobile/lib/main.dart

<ul><li>Import AppwriteService and AppwriteSyncManager<br> <li> Add _initializeAppwriteAssistant function to start Appwrite sync <br>manager<br> <li> Read appwrite_sync_enabled and appwrite_sync_interval from <br>SharedPreferences<br> <li> Initialize Appwrite assistant after SyncQueueService with error <br>handling</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/282/files#diff-b1af8ebfb559b57f56e8fc09be639e8c79833a6a806dca7bcb84f4d1b51f52a8">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>outbox_dao.dart</strong><dd><code>Remove duplicate sync trigger notifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/daos/outbox_dao.dart

<ul><li>Remove imports for SyncGuardian and GoogleDriveUnifiedSyncCoordinator<br> <li> Remove duplicate sync notifications to SyncGuardian and Coordinator<br> <li> Keep only AutoSyncEngine.notifyDataChange call to consolidate triggers<br> <li> Eliminate redundant async/await imports</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/282/files#diff-136f2387a5cc2b3175a187bcfa9e29c2c23e23c7ba57c336401072d31a7c77b9">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>google_drive_auto_sync_engine.dart</strong><dd><code>Validate network and sign-in before sync trigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/google_drive_auto_sync_engine.dart

<ul><li>Add network connection and sign-in validation before triggering <br>coordinator<br> <li> Return early if offline or not signed in to prevent unnecessary sync <br>attempts<br> <li> Clean up whitespace formatting in notifyDataChange method</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/282/files#diff-6ed93b022b521ae310aafbb48bf2a158ab034da14e9b006e0df5769df5a06e50">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>google_drive_unified_sync_coordinator.dart</strong><dd><code>Disable outbox watcher to prevent duplicate triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mobile/lib/services/google_drive_unified_sync_coordinator.dart

<ul><li>Remove outbox watcher subscription that was causing duplicate sync <br>triggers<br> <li> Eliminate redundant monitoring of outbox changes in _startMonitoring<br> <li> Keep pull-based monitoring intact for pull sync functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/NassarAlshabi1/marina-hotel-wit-app/pull/282/files#diff-d71efe8204fc328b92c45c99633c8b9264601d6e67b195ef67386fec0402ec08">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

