### PR TITLE
fix(sync): preserve pending retry flags and init appwrite background plugins

### DIFF
--- a/mobile/lib/tasks/appwrite_auto_sync_task.dart
+++ b/mobile/lib/tasks/appwrite_auto_sync_task.dart
@@ -41,7 +41,7 @@ void appwriteAutoSyncCallbackDispatcher() {
       developer.log(
         'Appwrite auto-sync background task failed',
         name: 'AppwriteAutoSyncTask',
-        error: error is Exception ? error.runtimeType.toString() : error,
+        error: error,
         stackTrace: stackTrace,
         level: 1000,
       );

--- a/mobile/lib/tasks/appwrite_auto_sync_task.dart
+++ b/mobile/lib/tasks/appwrite_auto_sync_task.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:developer' as developer;
+import 'dart:ui';
 import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
@@ -15,6 +17,7 @@ void appwriteAutoSyncCallbackDispatcher() {
   Workmanager().executeTask((taskName, inputData) async {
     try {
       WidgetsFlutterBinding.ensureInitialized();
+      DartPluginRegistrant.ensureInitialized();
 
       final prefs = await SharedPreferences.getInstance();
       final enabled = prefs.getBool('appwrite_sync_enabled') ?? true;
@@ -34,7 +37,14 @@ void appwriteAutoSyncCallbackDispatcher() {
       }
 
       return success;
-    } catch (e) {
+    } catch (error, stackTrace) {
+      developer.log(
+        'Appwrite auto-sync background task failed',
+        name: 'AppwriteAutoSyncTask',
+        error: error is Exception ? error.runtimeType.toString() : error,
+        stackTrace: stackTrace,
+        level: 1000,
+      );
       return false;
     }
   });
@@ -118,9 +128,9 @@ class AppwriteAutoSyncTask {
     if (!pending && !force) {
       return;
     }
-    await UnifiedSyncOrchestrator.instance.syncNow(
+    final success = await UnifiedSyncOrchestrator.instance.syncNow(
       reason: 'pending_appwrite_sync',
     );
-    await prefs.setBool(_kPendingFlagKey, false);
+    await prefs.setBool(_kPendingFlagKey, !success);
   }
 }

--- a/mobile/lib/tasks/auto_sync_task.dart
+++ b/mobile/lib/tasks/auto_sync_task.dart
@@ -126,9 +126,9 @@ class AutoSyncTask {
     if (!pending && !force) {
       return;
     }
-    await UnifiedSyncOrchestrator.instance.syncNow(
+    final success = await UnifiedSyncOrchestrator.instance.syncNow(
       reason: 'pending_sync',
     );
-    await prefs.setBool(_kPendingFlagKey, false);
+    await prefs.setBool(_kPendingFlagKey, !success);
   }
 }


### PR DESCRIPTION
## الملخص
هذا الـ PR يطبّق إصلاحات دقيقة لمسار المزامنة بدون توسيع نطاق التعديل، بهدف منع فقدان نية إعادة المحاولة عند فشل المزامنة.

## التغييرات
- إضافة `DartPluginRegistrant.ensureInitialized()` داخل callback الخاص بـ `AppwriteAutoSyncTask` في الخلفية.
- إضافة logging منظم للأخطاء في callback الخاص بـ Appwrite بدلاً من catch صامت.
- تعديل `consumePendingAndSync` في:
  - `mobile/lib/tasks/appwrite_auto_sync_task.dart`
  - `mobile/lib/tasks/auto_sync_task.dart`
  بحيث يبقى pending flag مفعّلًا عند فشل `syncNow`، ويتم مسحه فقط عند النجاح.

## الأثر
- يحافظ على التزامن في حالات الفشل المتقطع بدل إسقاط retry intent.
- يقلل احتمال فقدان مزامنات مؤجلة بسبب إعادة تعيين العلم بشكل غير صحيح.
- لا يغير معمارية المزامنة ولا سلوك التشغيل الناجح الحالي.

## التحقق
- تمت مراجعة الـ diff يدوياً والتأكد أن التعديل محصور في ملفّي المهام الخلفية.
- `git diff --check` بدون ملاحظات.
- تعذر تشغيل `flutter analyze` داخل بيئة التنفيذ لعدم توفر Flutter/Dart.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://app.warp.dev/conversation/d5171f5a-86c3-4569-bc31-3fbec6eae3aa_
_Run: https://oz.warp.dev/runs/019e42b9-12d0-7bed-955c-fdfcc8a0e8dc_

_This PR was generated with [Oz](https://warp.dev/oz)._
