### PR TITLE
Agent/Vivid Lunar A9uc

### DIFF
--- a/docs/appwrite-guides/SYNC_SYSTEM_CODE_REVIEW.md
+++ b/docs/appwrite-guides/SYNC_SYSTEM_CODE_REVIEW.md
@@ -1,7 +1,7 @@
-# مراجعة شاملة لكود نظام المزامنة — Appwrite Sync
+# مراجعة شاملة لكود نظام المزامنة — Appwrite Sync (v2)
 
 **تاريخ المراجعة:** 2026-06-28  
-**النطاق:** جميع ملفات المزامنة في `mobile/lib/services/sync_core/` + الملفات المرتبطة
+**النطاق:** جميع ملفات المزامنة — `sync_core/` + `daos/` + `delta_sync` + `appwrite_sync_manager`
 
 ---
 
@@ -15,221 +15,331 @@
 | حجم appwrite_sync_manager.dart | ~6300 سطر |
 | حجم sync_pull_service.dart | ~2524 سطر |
 | حجم sync_push_service.dart | ~1495 سطر |
+| عدد المشاكل الحرجة (P0) | 8 |
+| عدد المشاكل المهمة (P1) | 5 |
+| عدد المشاكل التحسينية (P2) | 7 |
 
 ---
 
-## 🏗️ البنية المعمارية (Architecture)
-
-### الطبقات
+## 🏗️ البنية المعمارية
 
 ```
-┌─────────────────────────────────────────────┐
-│         AppwriteSyncManager (6300 سطر)      │  ← المنسق الرئيسي
-├─────────────────────────────────────────────┤
-│  SyncPullService  │  SyncPushService        │  ← خدمات السحب والدفع
-├─────────────────────────────────────────────┤
-│  ConflictDetector │ SmartConflictResolver   │  ← كشف وحل التعارضات
-├─────────────────────────────────────────────┤
-│  VectorClock      │ OptimisticLockHelper    │  ← السببية والقفل التفاؤلي
-├─────────────────────────────────────────────┤
-│  CircuitBreaker   │ RetryStrategy           │  ← المرونة والהתאוששות
-├─────────────────────────────────────────────┤
-│  OutboxDao        │ AncestorCacheDao        │  ← التخزين المؤقت
-├─────────────────────────────────────────────┤
-│  AdapterRegistry  │ AppwriteService         │  ← المحولات والتواصل
-└─────────────────────────────────────────────┘
+┌──────────────────────────────────────────────┐
+│       AppwriteSyncManager (6300 سطر)         │ ← المنسق الرئيسي
+├──────────────────────────────────────────────┤
+│  SyncPullService  │  SyncPushService         │ ← خدمات السحب والدفع
+├──────────────────────────────────────────────┤
+│  AppwriteDeltaSync │  DeltaSyncService       │ ← مزامنة تفاضلية
+├──────────────────────────────────────────────┤
+│  ConflictDetector │ SmartConflictResolver    │ ← كشف وحل التعارضات
+├──────────────────────────────────────────────┤
+│  VectorClock      │ OptimisticLockHelper     │ ← السببية والقفل التفاؤلي
+├──────────────────────────────────────────────┤
+│  CircuitBreaker   │ RetryStrategy            │ ← المرونة والاستشفاء
+├──────────────────────────────────────────────┤
+│  OutboxDao        │ AncestorCacheDao         │ ← التخزين المؤقت
+├──────────────────────────────────────────────┤
+│  SyncLocks        │ SyncConstants            │ ← الأقفال والإعدادات
+└──────────────────────────────────────────────┘
 ```
-
-### أنماط التصميم المستخدمة
-
-| النمط | التطبيق | التقييم |
-|-------|---------|---------|
-| **Outbox Pattern** | `OutboxDao` — تغييرات محلية تُكتب أولاً ثم تُدفع للسحابة | ✅ ممتاز |
-| **Delta Sync** | `AppwriteDeltaSync` — سحب التغييرات فقط عبر `lastPullTs` | ✅ جيد |
-| **Vector Clocks** | `VectorClockService` — تحديد السببية بدلاً من LWW | ✅ ممتاز |
-| **3-Way Merge** | `SmartConflictResolver` + `AncestorCacheDao` | ✅ ممتاز |
-| **Circuit Breaker** | `CircuitBreaker` — حماية من انهيار الخدمة | ✅ جيد |
-| **Optimistic Locking** | `OptimisticLockDaoMixin` — منع الكتابة المتزامنة | ✅ جيد |
-| **Adapter Pattern** | `AdapterRegistry` — محولات لكل كيان | ✅ ممتاز |
 
 ---
 
-## ✅ نقاط القوة
+## 🔴 P0 — مشاكل حرجة (يجب إصلاحها فوراً)
 
-### 1. نظام كشف التعارضات المتطور (`conflict_detector.dart`)
-- **7 أنواع تعارض** مُعرّفة بدلاً من الثنائي البسيط
-- استخدام `VectorClock` لتحديد السببية بدلاً من الاعتماد على timestamps
-- كشف على مستوى الحقل (field-level) وليس السجل فقط
-- فصل الحقول المالية الحرجة (`amount`, `price`, `isVoided`) التي لا تُدمج تلقائياً
+### 1. `serverId` يستخدم `hashCode` — انتهاك لسلامة البيانات
+```
+الملف: appwrite_sync_manager.dart:2958 و sync_push_service.dart:827
+المشكلة: serverId: drift.Value(remoteDoc.$id.hashCode)
+التأثير: Object.hashCode غير ثابت عبر العمليات — قيم مختلفة لنفس المستند
+         على أجهزة مختلفة، مما يسبب فشل حل FK عبر الأجهزة.
+الحل: تخزين الـ $id النصي مباشرة (String) بدلاً من hashCode
+```
 
-### 2. حل التعارضات الذكي (`smart_conflict_resolver.dart`)
-- **17 سياسة كيان** مُعرّفة (كل كيان له قواعد خاصة)
-- **7 استراتيجيات حل**: `newerWins`, `localWins`, `remoteWins`, `maxValue`, `minValue`, `sum`, `concat`, `manual`
-- دمج نصي مع **deduplication** (`_concatWithDedup`) لمنع تضخم الملاحظات
-- استخدام `max(localTs, remoteTs)` بدلاً من `DateTime.now()` في الدمج (إصلاح idempotency)
-- تصعيد يدوي للحقول المالية الحرجة
+### 2. `_RemoteNewerResult.mergedData` لا يُستهلك أبداً
+```
+الملف: appwrite_sync_manager.dart:80-96 و sync loop
+المشكلة: SmartConflictResolver يُنتج بيانات مدمجة عبر 3-way merge
+         لكن الكود لا يطبق mergedData على قاعدة البيانات المحلية.
+         يتحقق فقط من shouldApplyRemote ويطبق remoteData الأصلي.
+التأثير: نتائج الدمج التلقائي تُفقد — التعارضات تُحل في الذاكرة فقط ولا تُحفظ.
+الحل: إذا hasMerge == true، طبق mergedData بدلاً من remoteData.
+```
 
-### 3. حماية البيانات المالية
-- الحقول المالية (`amount`, `paidAmount`, `totalAmount`) تُصعد دائماً للمراجعة اليدوية
-- `Financial immutability` في Pull: إذا كان السجل المحلي أحدث، لا يُكتب فوقه
-- منع إحياء السجلات المحذوفة softly من السحابة
+### 3. تكرار كود بنسبة ~80% بين ملفين ضخمين
+```
+الملف: sync_pull_service.dart (2524 سطر) و appwrite_sync_manager.dart (6307 سطر)
+المشكلة: 
+  - _syncRooms, _syncBookings, _syncEmployees... موجودة في الملفين
+  - _getXxxByLocalUuid و _getLocalXxxLastModified (+30 دالة) مكررة
+  - _asInt, _asIntNullable, _asIntSafe مكررة في 4 ملفات
+  - _performPostSyncIntegrityCheck مكرر
+التأثير: أي إصلاح bug يجب تطبيقه في مكانين — خطأ بشري محتمل
+الحل: دمج SyncPullService ككائن موحد يُستخدم من AppwriteSyncManager
+```
 
-### 4. التعامل مع Foreign Keys
-- **حل FK بثلاث مستويات**: UUID → id → serverId
-- تأجيل السجلات ذات FK المفقودة (`deferred` list) وإعادة المحاولة لاحقاً
-- رفع الكيانات الأب قبل الأبناء (employees قبل salary_withdrawals)
-- فحص سلامة البيانات بعد المزامنة (`_performPostSyncIntegrityCheck`)
+### 4. `outbox_dao.dart` — واجهة حل التعارضات اليدوية معطلة
+```
+الملف: outbox_dao.dart:604-615
+المشكلة: getConflicts() تعيد remotePayload = localPayload
+         مع تعليق // TODO: Fetch actual remote data
+التأثير: شاشة حل التعارضات اليدوية تظهر بيانات متطابقة للجهتين
+         — لا يمكن للمستخدم اتخاذ قرار صحيح.
+```
 
-### 5. نظام Vector Clock
-- تنظيف `vectorClock` من حساب الحقول المتغيرة (منع التعارضات الوهمية)
-- **bump VC قبل كل push** (`_bumpVectorClockBeforePush`) — إصلاح P0-1
-- دمج VC بعد كل عملية merge
+### 5. `_bumpVectorClockBeforePush` يزيد العداد حتى لو فشل الرفع
+```
+الملف: sync_push_service.dart:153-161
+المشكلة: يتم bump VC قبل الرفع. إذا فشل الرفع، العداد ارتفع محلياً
+         لكن السحابة لم تستلم البيانات.
+         المحاولة التالية تزيد مرة أخرى → فجوات في الساعة المنطقية.
+الحل: زيادة VC بعد نجاح الرفع، أو حفظ قيمة VC الأصلية للتراجع عند الفشل.
+```
 
-### 6. المرونة والاستشفاء
-- `CircuitBreaker` مع 3 حالات (closed/open/halfOpen)
-- `RetryStrategy` مع 3 أنماط (linear/exponential/fibonacci) + jitter
-- Adaptive batch size في Push (يزيد/ينقص بناءً على نسبة النجاح)
-- تنظيف stuck entries في Outbox عند التهيئة
+### 6. `_blacklistToRemote` يبتلع أخطاء JSON بصمت
+```
+الملف: sync_push_service.dart:473
+المشكلة: jsonDecode(item.content) as Map<String, dynamic> + catch (_) {}
+         إذا كان item.content يحتوي JSON تالف، ينتج {} فارغ
+         ويفقد جميع بيانات القائمة السوداء دون أي تحذير.
+الحل: تسجيل الخطأ مع LOG warning وعدم رفع بيانات فارغة.
+```
+
+### 7. إرسال كلمات المرور كنص صريح إلى Appwrite
+```
+الملف: sync_push_service.dart:1182-1241
+المشكلة: wa_api_token, telegram_bot_token, lark_app_secret
+         تُرسل مباشرة في _pushAppSettingsToCloud بدون تشفير.
+         مخزنة في Appwrite Cloud كنص صريح مقروء.
+التأثير: خرق أمني — أي شخص لديه وصول لقاعدة Appwrite
+         يمكنه قراءة جميع كلمات المرور والرموز.
+الحل: تشفير القيم الحساسة قبل الإرسال والتخزين.
+```
+
+### 8. `sync_pull_service.dart` — خطأ محتمل في `rowid` vs `id`
+```
+الملف: sync_pull_service.dart:1966-2024
+المشكلة: _performPostSyncIntegrityCheck يستخدم rowid من PRAGMA
+         ثم يبحث بـ t.id.equals(rowId as int). إذا كان الجدول
+         يستخدم WITHOUT ROWID أو id ليس alias لـ rowid،
+         فسيتم حذف السجل الخطأ.
+الحل: استخدام اسم العمود الصحيح من PRAGMA output أو البحث بـ localUuid.
+```
 
 ---
 
-## ⚠️ مشاكل وتحذيرات
+## 🟡 P1 — مشاكل مهمة
 
-### P0 — حرج
-
-#### 1. `appwrite_sync_manager.dart` ضخم جداً (~6300 سطر)
+### 9. `ConflictDetector._findChangedFields` — مقارنة سطحية
 ```
-المشكلة: ملف واحد يحتوي على معظم منطق المزامنة
-التأثير: صعوبة الصيانة والاختبار والتعاون
-الحل: تقسيم إلى:
-  - sync_orchestrator.dart (التنسيق)
-  - sync_device_manager.dart (إدارة الأجهزة)
-  - sync_entity_handlers.dart (معالجات الكيانات)
+الملف: conflict_detector.dart:231-250
+المشكلة: ancestor[key] != current[key] لا تدعم Map/List المتداخلة
+         مثلاً content = {"a": 1} vs {"a": 1} قد تُعتبر مختلفة
+         بسبب اختلاف مراجع الكائنات.
+الحل: استخدام DeepCollectionEquality من package:collection للمقارنة.
 ```
 
-#### 2. تكرار كود `_asInt` / `_asIntNullable` / `_asIntSafe`
+### 10. `sync_push_service.dart` — حلقة لا نهائية محتملة
 ```
-المشكلة: نفس الدوال مكررة في 4+ ملفات
-الملفات: sync_pull_service.dart, sync_push_service.dart, appwrite_sync_manager.dart, appwrite_delta_sync.dart
-الحل: نقل إلى ملف مشترك مثل sync_helpers.dart
-```
-
-#### 3. تكرار lookup functions (`_getXxxByLocalUuid`)
-```
-المشكلة: كل ملف يُعرّف نسخته الخاصة
-الحل: إنشاء SyncLookupService موحد أو استخدام AdapterRegistry
+الملف: sync_push_service.dart:92-150
+المشكلة: while(true) في _pushAllEntities ليس له حد أعلى صارم.
+         إذا استمرت إضافة عناصر outbox أثناء الدفع، قد تستمر للأبد.
+الحل: إضافة maxIterations أو maxDuration إجباري.
 ```
 
-### P1 — مهم
-
-#### 4. `_syncBlacklist` يكتب في `shiftNotes` table
+### 11. `appwrite_delta_sync.dart` — تكرار منطق Pull
 ```
+الملف: appwrite_delta_sync.dart
+المشكلة: AppwriteDeltaSync يكتب Companions مباشرة (insertOnConflictUpdate)
+         بينما SyncPullService يستخدم AdapterRegistry.upsertFromJson.
+         منطقان مختلفان لنفس العملية — صعوبة الصيانة.
+الحل: توحيد Pull logic لاستخدام AdapterRegistry في كل الحالات.
+```
+
+### 12. `_syncBlacklist` — ازدواجية تخزين
+```
+الملف: sync_pull_service.dart:1069-1184 و sync_push_service.dart:471-503
 المشكلة: blacklist يُخزّن في جدول shift_notes مع createdBy='blacklist'
-التأثير: ازدواجية في البيانات، صعوبة الاستعلام
-الحل: إنشاء جدول blacklist منفصل أو توضيح السبب بالتعليقات
+         بدلاً من جدول منفصل. 
+التأثير: ازدواجية، استعلامات معقدة، صعوبة فصل المنطق.
+الحل: إنشاء جدول blacklist منفصل أو استخدام حقل type بدلاً من createdBy.
 ```
 
-#### 5. `appwrite_delta_sync.dart` يحتوي على `insertOnConflictUpdate` مباشرة
+### 13. `_syncPriceAdjustments` — إنشاء service جديد لكل حلقة
 ```
-المشكلة: Pull في DeltaSync لا يستخدم AdapterRegistry (يكتب Companion مباشرة)
-بينما Pull في SyncPullService يستخدم AdapterRegistry
-التأثير: تكرار منطق التحويل وصعوبة الحفاظ على اتساق
-```
-
-#### 6. `sync_push_service.dart` لا يتحقق من نجاح الرفع
-```
-المشكلة: بعد upsertRoom/upsertBooking لا يتم التحقق من حفظ البيانات
-(ملاحظة: تم إضافة _verifyPushedBooking للحجوزات فقط)
-الحل: إضافة تحقق مشابه للكيانات المالية الحرجة
-```
-
-### P2 — تحسين
-
-#### 7. `_cleanupOutboxAfterPull` يفحص كل كيان بشكل منفصل
-```
-المشكلة: N استعلامات DB لكل كيان (17 كيان × M عناصر)
-التحسين: دمج الاستعلامات أو استخدام batch query
-```
-
-#### 8. `ConflictDetector._findChangedFields` لا يتعامل مع القيم المعقدة
-```
-المشكلة: المقارنة تستخدم `!=` مباشرة — لا تدعم Map/List嵌套
-التحسين: استخدام deep equality للمقارنة
-```
-
-#### 9. `SmartConflictResolver._applyRule` لـ `newerWins` يقارن timestamps فقط
-```
-المشكلة: لا يستخدم VectorClock لتحديد "الأحدث"
-يستخدم lastModified (الذي قد يكون متأثراً بـ clock skew)
-التحسين: دمج VectorClock في القرار
-```
-
-#### 10. `_pushAppSettingsToCloud` يرسل كلمات مرور كنص صريح
-```
-المشكلة: wa_api_token, telegram_bot_token, lark_app_secret تُرسل كما هي
-التحسين: تشفير القيم الحساسة قبل الإرسال
+الملف: sync_pull_service.dart:1681-1744
+المشكلة: BookingDerivedFieldsService(database) يُنشأ جديداً
+         لكل حجز نشط داخل الحلقة (~1717).
+الحل: إنشاء instance واحد وإعادة استخدامه.
 ```
 
 ---
 
-## 📋 تقييم كل ملف
+## 🟢 P2 — تحسينات مقترحة
 
-| الملف | الأسطر | التقييم | ملاحظات |
-|-------|--------|---------|---------|
-| `sync_pull_service.dart` | 2524 | ⭐⭐⭐⭐ | قوي، لكن يحتاج تقسيم |
-| `sync_push_service.dart` | 1495 | ⭐⭐⭐⭐ | جيد، VC bump ممتاز |
-| `conflict_detector.dart` | 260 | ⭐⭐⭐⭐⭐ | ممتاز ومُنظّم |
-| `smart_conflict_resolver.dart` | 611 | ⭐⭐⭐⭐⭐ | تصميم احترافي |
-| `vector_clock_service.dart` | 217 | ⭐⭐⭐⭐⭐ | نظيف ومكتمل |
-| `circuit_breaker.dart` | 203 | ⭐⭐⭐⭐ | جيد |
-| `retry_strategy.dart` | 159 | ⭐⭐⭐⭐ | جيد، fibonacci مبتكر |
-| `sync_metrics.dart` | 268 | ⭐⭐⭐⭐ | مفيد للمراقبة |
-| `sync_validator.dart` | 148 | ⭐⭐⭐ | بسيط، يحتاج توسيع |
-| `sync_error_handler.dart` | 231 | ⭐⭐⭐⭐ | تصنيف أخطاء جيد |
-| `sync_error_service.dart` | 110 | ⭐⭐⭐⭐ | توحيد ممتاز |
-| `optimistic_lock_helper.dart` | 70 | ⭐⭐⭐⭐ | نظيف |
-| `conflict_resolver.dart` | 204 | ⭐⭐⭐ | بسيط مقارنة بـ SmartConflictResolver |
-| `appwrite_delta_sync.dart` | 1200+ | ⭐⭐⭐⭐ | جيد لكن يكرر منطق Pull |
-| `appwrite_sync_manager.dart` | 6307 | ⭐⭐⭐ | يشتغل لكن ضخم جداً |
+### 14. `_cleanupOutboxAfterPull` — أداء
+```
+المشكلة: فحص كل كيان باستعلامات منفصلة (17 كيان × M عناصر)
+الحل: دمج الاستعلامات أو استخدام batch operations.
+```
+
+### 15. `SmartConflictResolver._applyRule` — newerWins لا يستخدم VectorClock
+```
+المشكلة: newerWins يقارن lastModified timestamps فقط
+         التي قد تتأثر بـ clock skew بين الأجهزة.
+الحل: استخدام VectorClock لتحديد "الأحدث" سببياً.
+```
+
+### 16. `outbox_dao.dart` — خطأ صامت في secondary delivery
+```
+الملف: outbox_dao.dart:110-115
+المشكلة: merge() يحاول الوصول لـ SharedPreferences في try-catch
+         وإذا فشل (مثلاً SharedPreferences not ready)،
+         يُعلم deliveredToSecondary = true خطأً.
+```
+
+### 17. `sync_enums.dart` و `sync_constants.dart` — أرقام سحرية
+```
+المشكلة: tableOrder في sync_constants لا يتحقق تلقائياً من اتساقه
+         مع مخطط قاعدة البيانات الفعلي.
+الحل: إضافة فحص في وقت التهيئة أو إنشاء الترتيب تلقائياً من Drift schema.
+```
+
+### 18. `central_sync_coordinator.dart` — نمط Singleton غير مكتمل
+```
+المشكلة: factory constructor يأخذ معاملات لكن يتجاهلها بعد أول إنشاء.
+         المتصل الثاني يحصل على instance الأول بدون تحذير.
+```
+
+### 19. `AppwriteSyncManager.sync()` — دالة ضخمة جداً
+```
+المشكلة: sync() بطول ~680 سطر مع try/catch متداخلة عميقاً.
+         صعوبة الاختبار والتصحيح.
+الحل: استخراج كل _doSyncXxx إلى كلاس منفصل أو استخدام Chain of Responsibility.
+```
+
+### 20. `appwrite_sync_manager.dart:1284` — TimeoutException لا يمكن حدوثه
+```
+المشكلة: catch على TimeoutException حول SyncLocks.appwriteSyncLock.synchronized()
+         لكن synchronized() من package:synchronized لا يرمي TimeoutException.
+         كتلة catch هذه لا يمكن الوصول إليها أبداً.
+```
 
 ---
 
-## 🔧 توصيات التحسين
+## ✅ نقاط القوة المعمارية
 
-### عاجل (قبل الإنتاج)
-1. ✅ **تم بالفعل** — Vector Clock bumping قبل Push (P0-1)
-2. ✅ **تم بالفعل** — منع إحياء السجلات المحذوفة softly
-3. ✅ **تم بالفعل** — فحص سلامة البيانات بعد المزامنة
-4. ✅ **تم بالفعل** — حل FK بثلاث مستويات
-
-### مهم (المرحلة 2)
-5. تقسيم `appwrite_sync_manager.dart` إلى ملفات أصغر
-6. نقل `_asInt` و `_getXxxByLocalUuid` إلى ملف مشترك
-7. توحيد Pull logic بين DeltaSync و SyncPullService
-8. إضافة تحقق بعد الرفع للكيانات المالية
-
-### تحسينات (المرحلة 3)
-9. تحسين `_cleanupOutboxAfterPull` بأداء أفضل
-10. دمج VectorClock في قرارات newerWins
-11. تشفير البيانات الحساسة في app_settings
-12. إضافة اختبارات unit test للكشف والحل
+| # | الميزة | التفاصيل |
+|---|--------|----------|
+| 1 | **7 أنواع تعارض** | `conflict_detector.dart` — يتجاوز ثنائية "تحديث/تجاهل" البسيطة |
+| 2 | **17 سياسة كيان × 8 استراتيجيات حل** | `smart_conflict_resolver.dart` — تخصيص كامل لكل جدول |
+| 3 | **Vector Clock حقيقي** | `vector_clock_service.dart` — تحديد سبببية بدلاً من LWW |
+| 4 | **3-Way Merge مع AncestorCache** | حل التعارضات المتزامنة تلقائياً عبر مقارنة مع ancestor |
+| 5 | **Outbox Pattern مزدوج التسليم** | تتبع delivery إلى primary + secondary Appwrite instances |
+| 6 | **Delta Sync مع Mirror Snapshots** | SHA-1 hashing للكشف عن التغييرات بكفاءة |
+| 7 | **Adaptive Batch Size** | 1.3x عند النجاح، 0.6x عند الفشل (10-200) |
+| 8 | **حل FK ثلاثي المستويات** | UUID → localId → serverId |
+| 9 | **تأجيل وإعادة محاولة** | Deferred retry للسجلات ذات FK المفقودة |
+| 10 | **فحص سلامة البيانات** | `PRAGMA foreign_key_check` + إصلاح تلقائي للسجلات اليتيمة |
+| 11 | **Circuit Breaker** | 3 حالات (closed/open/halfOpen) + إعادة تعيين تلقائية |
+| 12 | **RetryStrategy متعدد الأنماط** | linear + exponential + fibonacci مع jitter |
+| 13 | **Financial Immutability** | منع الكتابة فوق البيانات المالية المحلية الأحدث |
+| 14 | **منع إحياء السجلات المحذوفة** | Soft delete له أولوية على التحديثات البعيدة |
+| 15 | **Idempotency Keys** | `entity:op:localUuid:outboxId` مع graceful fallback |
 
 ---
 
-## 🎯 الخلاصة
+## 📋 تقييم كل ملف (محدث)
 
-نظام المزامنة **قوي واحترافي** بشكل عام. البنية المعمارية سليمة وتتبع أفضل الممارسات:
-- Outbox Pattern للدفع
-- Delta Sync للسحب
-- Vector Clocks للسببية
-- 3-Way Merge للتعارضات
-- Circuit Breaker للمرونة
+| الملف | الأسطر | التقييم | أهم مشكلة |
+|-------|--------|---------|-----------|
+| `conflict_detector.dart` | 260 | ⭐⭐⭐⭐⭐ | مقارنة سطحية للقيم المتداخلة |
+| `smart_conflict_resolver.dart` | 611 | ⭐⭐⭐⭐⭐ | newerWins لا يستخدم VC |
+| `vector_clock_service.dart` | 217 | ⭐⭐⭐⭐⭐ | — |
+| `conflict_resolver.dart` | 204 | ⭐⭐⭐ | بسيط، لا يستخدم VC |
+| `circuit_breaker.dart` | 203 | ⭐⭐⭐⭐ | — |
+| `retry_strategy.dart` | 159 | ⭐⭐⭐⭐ | — |
+| `optimistic_lock_helper.dart` | 70 | ⭐⭐⭐⭐ | — |
+| `sync_validator.dart` | 148 | ⭐⭐⭐ | بسيط جداً |
+| `sync_error_handler.dart` | 231 | ⭐⭐⭐⭐ | — |
+| `sync_error_service.dart` | 110 | ⭐⭐⭐⭐ | — |
+| `sync_metrics.dart` | 268 | ⭐⭐⭐⭐ | — |
+| `sync_push_service.dart` | 1495 | ⭐⭐⭐ | **serverId=hashCode** + VC bump قبل الرفع |
+| `sync_pull_service.dart` | 2524 | ⭐⭐⭐ | **تكرار 80%** مع sync_manager |
+| `appwrite_delta_sync.dart` | 1200+ | ⭐⭐⭐ | يكرر Pull logic |
+| `delta_sync_service.dart` | 600+ | ⭐⭐⭐⭐ | timestamp normalization edge cases |
+| `appwrite_sync_manager.dart` | 6307 | ⭐⭐ | **ضخم + mergedData لا يُستهلك + serverId=hashCode** |
+| `outbox_dao.dart` | 700+ | ⭐⭐⭐ | **getConflicts() معطل** + secondary delivery صامت |
+| `sync_locks.dart` | 12 | ⭐⭐⭐⭐ | بعض الأقفال غير مستخدمة |
+| `sync_constants.dart` | 51 | ⭐⭐⭐⭐ | tableOrder لا يتحقق تلقائياً |
+| `central_sync_coordinator.dart` | صغير | ⭐⭐⭐ | Singleton تجاهل معاملات |
 
-**أبرز الإصلاحات التي تمت مؤخراً** (2026-06-28):
-- P0-1: Vector Clock bumping قبل Push
-- P0-2: منع إحياء السجلات المحذوفة
-- P0-3: فحص _isRemoteDataNewer مع SmartConflictResolver
-- P0-4: AncestorCacheDao لتخزين الـ ancestor
-- P0-5: إزالة `status` من الحقول الحرجة (للسماح بـ newerWins)
+---
 
-**أكبر تحدٍ**: حجم الملفات — `appwrite_sync_manager.dart` بـ 6300 سطر يحتاج تقسيم عاجل.
+## 📊 إحصاءات كمية
+
+| النوع | العدد |
+|-------|-------|
+| تكرار دوال `_asInt` | 3 ملفات × 3 دوال = 9 تكرارات |
+| تكرار `_getXxxByLocalUuid` | ملفين × 15 دالة = 30 تكراراً |
+| تكرار `_syncXxx` methods | ملفين × 20 method = 40 تكراراً |
+| تكرار `_getLocalXxxLastModified` | ملفين × 17 دالة = 34 تكراراً |
+| كيانات متزامنة | 17 كيان |
+| استراتيجيات حل التعارض | 8 استراتيجيات |
+| سياسات كيانات للحل | 17 سياسة |
+| أنماط retry backoff | 3 أنماط |
+| حالات Circuit Breaker | 3 حالات |
+| مستويات حل FK | 3 مستويات |
+| أنواع التعارضات | 7 أنواع |
+
+---
+
+## 🔧 خارطة طريق الإصلاح
+
+### المرحلة 1 — إصلاح فوري (هذا الأسبوع)
+
+| # | المشكلة | الأولوية | التقدير |
+|---|---------|----------|---------|
+| 1 | `serverId: hashCode` → تخزين string | P0 🔴 | ساعة |
+| 2 | استهلاك `mergedData` في _RemoteNewerResult | P0 🔴 | 3 ساعات |
+| 3 | `outbox_dao.getConflicts()` — جلب بيانات بعيدة حقيقية | P0 🔴 | 4 ساعات |
+| 4 | تشفير القيم الحساسة في app_settings | P0 🔴 | ساعتين |
+| 5 | إصلاح `_blacklistToRemote` — تسجيل خطأ JSON | P0 🔴 | 30 دقيقة |
+| 6 | إصلاح `rowid` vs `id` في فحص السلامة | P0 🔴 | ساعة |
+
+### المرحلة 2 — دمج وتنظيف (الأسبوع القادم)
+
+| # | المهمة | التقدير |
+|---|--------|---------|
+| 7 | دمج `sync_pull_service` + `appwrite_sync_manager` (إزالة التكرار) | 3 أيام |
+| 8 | نقل `_asInt` و lookup functions إلى `sync_helpers.dart` | يوم |
+| 9 | توحيد Pull logic بين DeltaSync و SyncPullService | يومين |
+| 10 | نقل bump VC إلى ما بعد نجاح الرفع | 3 ساعات |
+| 11 | إضافة maxIterations لحلقة `_pushAllEntities` | 30 دقيقة |
+
+### المرحلة 3 — تحسينات (لاحقاً)
+
+| # | المهمة | التقدير |
+|---|--------|---------|
+| 12 | تقسيم `appwrite_sync_manager.dart` إلى 4-5 ملفات | 5 أيام |
+| 13 | إضافة deep equality في ConflictDetector | 3 ساعات |
+| 14 | دمج VectorClock في newerWins | 4 ساعات |
+| 15 | تحسين أداء `_cleanupOutboxAfterPull` | 3 ساعات |
+| 16 | فصل جدول blacklist عن shift_notes | يومين |
+| 17 | إضافة unit tests للكشف والحل | 3 أيام |
+
+---
+
+## 🎯 الخلاصة النهائية
+
+نظام المزامنة **احترافي وقوي** في تصميمه المعماري:
+- Outbox Pattern + Delta Sync + Vector Clocks + 3-Way Merge
+- 17 كياناً متزامناً مع سياسات حل مخصصة لكل منها
+- Circuit Breaker + Adaptive Batch + Deferred Retry للمرونة
+
+**لكن** حجم الملفات وتكرار الكود يشكلان خطراً على الصيانة. أبرز المشاكل:
+
+1. 🔴 **3 Bugs حرجة في سلامة البيانات** (`serverId=hashCode`, `mergedData` لا يُستهلك, `getConflicts()` معطل)
+2. 🔴 **80% تكرار كود** بين ملفين — أي fix يجب تطبيقه مرتين
+3. 🔴 **كلمات مرور كنص صريح** في Appwrite Cloud
+4. 🔴 **حجم `appwrite_sync_manager.dart`** = 6300 سطر في ملف واحد

--- a/docs/appwrite-guides/SYNC_SYSTEM_CODE_REVIEW.md
+++ b/docs/appwrite-guides/SYNC_SYSTEM_CODE_REVIEW.md
@@ -1,0 +1,235 @@
+# مراجعة شاملة لكود نظام المزامنة — Appwrite Sync
+
+**تاريخ المراجعة:** 2026-06-28  
+**النطاق:** جميع ملفات المزامنة في `mobile/lib/services/sync_core/` + الملفات المرتبطة
+
+---
+
+## 📊 ملخص تنفيذي
+
+| المقياس | القيمة |
+|---------|--------|
+| إجمالي ملفات المزامنة | +80 ملف |
+| ملفات sync_core | 14 ملف |
+| الكيانات المتزامنة | 17 كيان |
+| حجم appwrite_sync_manager.dart | ~6300 سطر |
+| حجم sync_pull_service.dart | ~2524 سطر |
+| حجم sync_push_service.dart | ~1495 سطر |
+
+---
+
+## 🏗️ البنية المعمارية (Architecture)
+
+### الطبقات
+
+```
+┌─────────────────────────────────────────────┐
+│         AppwriteSyncManager (6300 سطر)      │  ← المنسق الرئيسي
+├─────────────────────────────────────────────┤
+│  SyncPullService  │  SyncPushService        │  ← خدمات السحب والدفع
+├─────────────────────────────────────────────┤
+│  ConflictDetector │ SmartConflictResolver   │  ← كشف وحل التعارضات
+├─────────────────────────────────────────────┤
+│  VectorClock      │ OptimisticLockHelper    │  ← السببية والقفل التفاؤلي
+├─────────────────────────────────────────────┤
+│  CircuitBreaker   │ RetryStrategy           │  ← المرونة والהתאוששות
+├─────────────────────────────────────────────┤
+│  OutboxDao        │ AncestorCacheDao        │  ← التخزين المؤقت
+├─────────────────────────────────────────────┤
+│  AdapterRegistry  │ AppwriteService         │  ← المحولات والتواصل
+└─────────────────────────────────────────────┘
+```
+
+### أنماط التصميم المستخدمة
+
+| النمط | التطبيق | التقييم |
+|-------|---------|---------|
+| **Outbox Pattern** | `OutboxDao` — تغييرات محلية تُكتب أولاً ثم تُدفع للسحابة | ✅ ممتاز |
+| **Delta Sync** | `AppwriteDeltaSync` — سحب التغييرات فقط عبر `lastPullTs` | ✅ جيد |
+| **Vector Clocks** | `VectorClockService` — تحديد السببية بدلاً من LWW | ✅ ممتاز |
+| **3-Way Merge** | `SmartConflictResolver` + `AncestorCacheDao` | ✅ ممتاز |
+| **Circuit Breaker** | `CircuitBreaker` — حماية من انهيار الخدمة | ✅ جيد |
+| **Optimistic Locking** | `OptimisticLockDaoMixin` — منع الكتابة المتزامنة | ✅ جيد |
+| **Adapter Pattern** | `AdapterRegistry` — محولات لكل كيان | ✅ ممتاز |
+
+---
+
+## ✅ نقاط القوة
+
+### 1. نظام كشف التعارضات المتطور (`conflict_detector.dart`)
+- **7 أنواع تعارض** مُعرّفة بدلاً من الثنائي البسيط
+- استخدام `VectorClock` لتحديد السببية بدلاً من الاعتماد على timestamps
+- كشف على مستوى الحقل (field-level) وليس السجل فقط
+- فصل الحقول المالية الحرجة (`amount`, `price`, `isVoided`) التي لا تُدمج تلقائياً
+
+### 2. حل التعارضات الذكي (`smart_conflict_resolver.dart`)
+- **17 سياسة كيان** مُعرّفة (كل كيان له قواعد خاصة)
+- **7 استراتيجيات حل**: `newerWins`, `localWins`, `remoteWins`, `maxValue`, `minValue`, `sum`, `concat`, `manual`
+- دمج نصي مع **deduplication** (`_concatWithDedup`) لمنع تضخم الملاحظات
+- استخدام `max(localTs, remoteTs)` بدلاً من `DateTime.now()` في الدمج (إصلاح idempotency)
+- تصعيد يدوي للحقول المالية الحرجة
+
+### 3. حماية البيانات المالية
+- الحقول المالية (`amount`, `paidAmount`, `totalAmount`) تُصعد دائماً للمراجعة اليدوية
+- `Financial immutability` في Pull: إذا كان السجل المحلي أحدث، لا يُكتب فوقه
+- منع إحياء السجلات المحذوفة softly من السحابة
+
+### 4. التعامل مع Foreign Keys
+- **حل FK بثلاث مستويات**: UUID → id → serverId
+- تأجيل السجلات ذات FK المفقودة (`deferred` list) وإعادة المحاولة لاحقاً
+- رفع الكيانات الأب قبل الأبناء (employees قبل salary_withdrawals)
+- فحص سلامة البيانات بعد المزامنة (`_performPostSyncIntegrityCheck`)
+
+### 5. نظام Vector Clock
+- تنظيف `vectorClock` من حساب الحقول المتغيرة (منع التعارضات الوهمية)
+- **bump VC قبل كل push** (`_bumpVectorClockBeforePush`) — إصلاح P0-1
+- دمج VC بعد كل عملية merge
+
+### 6. المرونة والاستشفاء
+- `CircuitBreaker` مع 3 حالات (closed/open/halfOpen)
+- `RetryStrategy` مع 3 أنماط (linear/exponential/fibonacci) + jitter
+- Adaptive batch size في Push (يزيد/ينقص بناءً على نسبة النجاح)
+- تنظيف stuck entries في Outbox عند التهيئة
+
+---
+
+## ⚠️ مشاكل وتحذيرات
+
+### P0 — حرج
+
+#### 1. `appwrite_sync_manager.dart` ضخم جداً (~6300 سطر)
+```
+المشكلة: ملف واحد يحتوي على معظم منطق المزامنة
+التأثير: صعوبة الصيانة والاختبار والتعاون
+الحل: تقسيم إلى:
+  - sync_orchestrator.dart (التنسيق)
+  - sync_device_manager.dart (إدارة الأجهزة)
+  - sync_entity_handlers.dart (معالجات الكيانات)
+```
+
+#### 2. تكرار كود `_asInt` / `_asIntNullable` / `_asIntSafe`
+```
+المشكلة: نفس الدوال مكررة في 4+ ملفات
+الملفات: sync_pull_service.dart, sync_push_service.dart, appwrite_sync_manager.dart, appwrite_delta_sync.dart
+الحل: نقل إلى ملف مشترك مثل sync_helpers.dart
+```
+
+#### 3. تكرار lookup functions (`_getXxxByLocalUuid`)
+```
+المشكلة: كل ملف يُعرّف نسخته الخاصة
+الحل: إنشاء SyncLookupService موحد أو استخدام AdapterRegistry
+```
+
+### P1 — مهم
+
+#### 4. `_syncBlacklist` يكتب في `shiftNotes` table
+```
+المشكلة: blacklist يُخزّن في جدول shift_notes مع createdBy='blacklist'
+التأثير: ازدواجية في البيانات، صعوبة الاستعلام
+الحل: إنشاء جدول blacklist منفصل أو توضيح السبب بالتعليقات
+```
+
+#### 5. `appwrite_delta_sync.dart` يحتوي على `insertOnConflictUpdate` مباشرة
+```
+المشكلة: Pull في DeltaSync لا يستخدم AdapterRegistry (يكتب Companion مباشرة)
+بينما Pull في SyncPullService يستخدم AdapterRegistry
+التأثير: تكرار منطق التحويل وصعوبة الحفاظ على اتساق
+```
+
+#### 6. `sync_push_service.dart` لا يتحقق من نجاح الرفع
+```
+المشكلة: بعد upsertRoom/upsertBooking لا يتم التحقق من حفظ البيانات
+(ملاحظة: تم إضافة _verifyPushedBooking للحجوزات فقط)
+الحل: إضافة تحقق مشابه للكيانات المالية الحرجة
+```
+
+### P2 — تحسين
+
+#### 7. `_cleanupOutboxAfterPull` يفحص كل كيان بشكل منفصل
+```
+المشكلة: N استعلامات DB لكل كيان (17 كيان × M عناصر)
+التحسين: دمج الاستعلامات أو استخدام batch query
+```
+
+#### 8. `ConflictDetector._findChangedFields` لا يتعامل مع القيم المعقدة
+```
+المشكلة: المقارنة تستخدم `!=` مباشرة — لا تدعم Map/List嵌套
+التحسين: استخدام deep equality للمقارنة
+```
+
+#### 9. `SmartConflictResolver._applyRule` لـ `newerWins` يقارن timestamps فقط
+```
+المشكلة: لا يستخدم VectorClock لتحديد "الأحدث"
+يستخدم lastModified (الذي قد يكون متأثراً بـ clock skew)
+التحسين: دمج VectorClock في القرار
+```
+
+#### 10. `_pushAppSettingsToCloud` يرسل كلمات مرور كنص صريح
+```
+المشكلة: wa_api_token, telegram_bot_token, lark_app_secret تُرسل كما هي
+التحسين: تشفير القيم الحساسة قبل الإرسال
+```
+
+---
+
+## 📋 تقييم كل ملف
+
+| الملف | الأسطر | التقييم | ملاحظات |
+|-------|--------|---------|---------|
+| `sync_pull_service.dart` | 2524 | ⭐⭐⭐⭐ | قوي، لكن يحتاج تقسيم |
+| `sync_push_service.dart` | 1495 | ⭐⭐⭐⭐ | جيد، VC bump ممتاز |
+| `conflict_detector.dart` | 260 | ⭐⭐⭐⭐⭐ | ممتاز ومُنظّم |
+| `smart_conflict_resolver.dart` | 611 | ⭐⭐⭐⭐⭐ | تصميم احترافي |
+| `vector_clock_service.dart` | 217 | ⭐⭐⭐⭐⭐ | نظيف ومكتمل |
+| `circuit_breaker.dart` | 203 | ⭐⭐⭐⭐ | جيد |
+| `retry_strategy.dart` | 159 | ⭐⭐⭐⭐ | جيد، fibonacci مبتكر |
+| `sync_metrics.dart` | 268 | ⭐⭐⭐⭐ | مفيد للمراقبة |
+| `sync_validator.dart` | 148 | ⭐⭐⭐ | بسيط، يحتاج توسيع |
+| `sync_error_handler.dart` | 231 | ⭐⭐⭐⭐ | تصنيف أخطاء جيد |
+| `sync_error_service.dart` | 110 | ⭐⭐⭐⭐ | توحيد ممتاز |
+| `optimistic_lock_helper.dart` | 70 | ⭐⭐⭐⭐ | نظيف |
+| `conflict_resolver.dart` | 204 | ⭐⭐⭐ | بسيط مقارنة بـ SmartConflictResolver |
+| `appwrite_delta_sync.dart` | 1200+ | ⭐⭐⭐⭐ | جيد لكن يكرر منطق Pull |
+| `appwrite_sync_manager.dart` | 6307 | ⭐⭐⭐ | يشتغل لكن ضخم جداً |
+
+---
+
+## 🔧 توصيات التحسين
+
+### عاجل (قبل الإنتاج)
+1. ✅ **تم بالفعل** — Vector Clock bumping قبل Push (P0-1)
+2. ✅ **تم بالفعل** — منع إحياء السجلات المحذوفة softly
+3. ✅ **تم بالفعل** — فحص سلامة البيانات بعد المزامنة
+4. ✅ **تم بالفعل** — حل FK بثلاث مستويات
+
+### مهم (المرحلة 2)
+5. تقسيم `appwrite_sync_manager.dart` إلى ملفات أصغر
+6. نقل `_asInt` و `_getXxxByLocalUuid` إلى ملف مشترك
+7. توحيد Pull logic بين DeltaSync و SyncPullService
+8. إضافة تحقق بعد الرفع للكيانات المالية
+
+### تحسينات (المرحلة 3)
+9. تحسين `_cleanupOutboxAfterPull` بأداء أفضل
+10. دمج VectorClock في قرارات newerWins
+11. تشفير البيانات الحساسة في app_settings
+12. إضافة اختبارات unit test للكشف والحل
+
+---
+
+## 🎯 الخلاصة
+
+نظام المزامنة **قوي واحترافي** بشكل عام. البنية المعمارية سليمة وتتبع أفضل الممارسات:
+- Outbox Pattern للدفع
+- Delta Sync للسحب
+- Vector Clocks للسببية
+- 3-Way Merge للتعارضات
+- Circuit Breaker للمرونة
+
+**أبرز الإصلاحات التي تمت مؤخراً** (2026-06-28):
+- P0-1: Vector Clock bumping قبل Push
+- P0-2: منع إحياء السجلات المحذوفة
+- P0-3: فحص _isRemoteDataNewer مع SmartConflictResolver
+- P0-4: AncestorCacheDao لتخزين الـ ancestor
+- P0-5: إزالة `status` من الحقول الحرجة (للسماح بـ newerWins)
+
+**أكبر تحدٍ**: حجم الملفات — `appwrite_sync_manager.dart` بـ 6300 سطر يحتاج تقسيم عاجل.

--- a/mobile/lib/screens/settings/secondary_appwrite_settings_screen.dart
+++ b/mobile/lib/screens/settings/secondary_appwrite_settings_screen.dart
@@ -1,23 +1,13 @@
-// ignore_for_file: use_build_context_synchronously, unawaited_futures
-
+// ignore_for_file: directives_ordering, prefer_const_constructors, use_if_null_to_convert_nulls_to_bools, unawaited_futures, use_build_context_synchronously
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 
-import '../../components/app_scaffold.dart';
-import '../../providers/repository_providers.dart';
-import '../../providers/secondary_sync_provider.dart';
-import '../../services/daos/outbox_dao.dart';
 import '../../services/secondary_appwrite_config.dart';
 import '../../services/secondary_appwrite_service.dart';
-import '../../services/secondary_sync_manager.dart';
+import '../../services/appwrite_sync_manager.dart';
 
 /// شاشة إعدادات الوجهة الثانوية لـ Appwrite
-///
-/// تتحكم في:
-/// - تفعيل/تعطيل Secondary بالكامل
-/// - تفعيل/تعطيل **الرفع (Push)** عبر outbox — رفع الأحداث أول بأول
-/// - تفعيل/تعطيل **السحب (Pull)** — Failover للقراءة عند تعطل Primary
+/// تتيح: تفعيل/تعطيل + إدخال بيانات الاتصال + خيارات push/pull منفصلة + failover
 class SecondaryAppwriteSettingsScreen extends ConsumerStatefulWidget {
   const SecondaryAppwriteSettingsScreen({super.key});
 
@@ -32,14 +22,24 @@ class _SecondaryAppwriteSettingsScreenState
   final _projectIdCtrl = TextEditingController();
   final _databaseIdCtrl = TextEditingController();
   final _apiKeyCtrl = TextEditingController();
-
   bool _obscureApiKey = true;
+  bool _testingConnection = false;
+  String? _testResult;
+  bool? _testSuccess;
+  int? _testLatency;
   bool _saving = false;
-  bool _testing = false;
-  bool _syncing = false;
-  String? _message;
-  bool? _success;
-  DateTime? _lastSync;
+  bool _switchingFailover = false;
+  bool _uploadingFullBackup = false;
+  String _fullBackupResult = '';
+  bool? _fullBackupSuccess;
+  int _totalCollectionsToUpload = 0;
+  int _completedCollections = 0;
+  int _totalRecordsToUpload = 0;
+  int _completedRecords = 0;
+  String _currentCollectionName = '';
+  DateTime? _uploadStartTime;
+  int _currentCollectionRecords = 0;
+  int _currentCollectionDone = 0;
 
   @override
   void initState() {
@@ -48,14 +48,11 @@ class _SecondaryAppwriteSettingsScreenState
   }
 
   Future<void> _loadConfig() async {
-    await SecondaryAppwriteConfig.ensureInitialized();
-    setState(() {
-      _endpointCtrl.text = SecondaryAppwriteConfig.endpoint;
-      _projectIdCtrl.text = SecondaryAppwriteConfig.projectId;
-      _databaseIdCtrl.text = SecondaryAppwriteConfig.databaseId;
-      _apiKeyCtrl.text = SecondaryAppwriteConfig.apiKey;
-      _lastSync = SecondaryAppwriteConfig.lastSyncTime;
-    });
+    _endpointCtrl.text = SecondaryAppwriteConfig.endpoint;
+    _projectIdCtrl.text = SecondaryAppwriteConfig.projectId;
+    _databaseIdCtrl.text = SecondaryAppwriteConfig.databaseId;
+    _apiKeyCtrl.text = SecondaryAppwriteConfig.apiKey;
+    setState(() {});
   }
 
   @override
@@ -79,689 +76,1039 @@ class _SecondaryAppwriteSettingsScreenState
         pushEnabled: SecondaryAppwriteConfig.isPushEnabled,
         pullEnabled: SecondaryAppwriteConfig.isPullEnabled,
       );
-      SecondaryAppwriteService.instance.invalidate();
-      ref.read(secondarySyncProvider.notifier).refresh();
-      _showMessage(true, '✅ تم الحفظ');
-    } catch (e) {
-      _showMessage(false, '❌ فشل: $e');
-    } finally {
-      setState(() => _saving = false);
-    }
-  }
+      // إجبار SecondaryAppwriteService على إعادة التهيئة
+      SecondaryAppwriteService().invalidate();
 
-  /// تفعيل/تعطيل Secondary بالكامل
-  ///
-  /// عند التفعيل:
-  ///   - نبدأ المزامنة التلقائية للرفع (Push) كل 15 دقيقة
-  ///   - نُعلّم جميع سجلات outbox المحلية كـ "غير مُسلّمة للثانوي"
-  ///     ليتم رفعها للثانوي في الدورة القادمة
-  ///
-  /// عند التعطيل:
-  ///   - نوقف المزامنة التلقائية
-  ///   - نُعلّم جميع السجلات كـ "مُسلّمة للثانوي" (للسماح بحذفها بعد نجاح Primary)
-  Future<void> _toggleSync(bool value) async {
-    await SecondaryAppwriteConfig.saveConfig(
-      enabled: value,
-      endpoint: _endpointCtrl.text.trim(),
-      projectId: _projectIdCtrl.text.trim(),
-      databaseId: _databaseIdCtrl.text.trim(),
-      apiKey: _apiKeyCtrl.text.trim(),
-      pushEnabled: SecondaryAppwriteConfig.isPushEnabled,
-      pullEnabled: SecondaryAppwriteConfig.isPullEnabled,
-    );
-
-    ref.read(secondarySyncProvider.notifier).refresh();
-
-    // ✅ تحديث علامات التسليم في outbox
-    final db = ref.read(databaseProvider);
-    final outboxDao = OutboxDao(db);
-    if (value) {
-      // تفعيل: نُعلّم كل السجلات كـ "غير مُسلّمة للثانوي" ليتم رفعها
-      final count = await outboxDao.markAllLocalAsUndeliveredToSecondary();
-      debugPrint('🔵 [Secondary] Marked $count records as undelivered to secondary');
-      if (SecondaryAppwriteConfig.isPushEnabled) {
-        SecondarySyncManager.instance.startAutoSync();
-
-        // ✅ إصلاح (2026-06-28): مزامنة فورية للسجلات المتراكمة
-        // لا ننتظر 15 دقيقة — ارفع فوراً
-       
-        SecondarySyncManager.instance.sync().then((result) {
-          if (mounted && result.pushed > 0) {
-            _showMessage(true, '✅ تم رفع ${result.pushed} سجل للوجهة الثانوية');
-            setState(() => _lastSync = DateTime.now());
-          }
-        }).catchError((Object e) {
-          if (mounted) {
-            _showMessage(false, '⚠️ فشل الرفع الفوري: $e — سيُعاد تلقائياً');
-          }
-        });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('✅ تم حفظ الإعدادات'),
+            backgroundColor: Colors.green,
+          ),
+        );
       }
-    } else {
-      // تعطيل: نُعلّم كل السجلات كـ "مُسلّمة للثانوي" لمنع حجبها
-      final count = await outboxDao.markAllLocalAsDeliveredToSecondary();
-      debugPrint('🔵 [Secondary] Marked $count records as delivered to secondary (disabled)');
-      SecondarySyncManager.instance.stopAutoSync();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('❌ فشل الحفظ: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
     }
-
-    setState(() {});
-    _showMessage(true, value ? '✅ المزامنة مُفعّلة' : '⏹️ المزامنة معطّلة');
-  }
-
-  /// تفعيل/تعطيل الرفع (Push) لـ Secondary عبر outbox
-  ///
-  /// عند التفعيل: نبدأ المزامنة التلقائية + مزامنة فورية للسجلات المتراكمة
-  /// عند التعطيل: نوقف المزامنة التلقائية، لكن السجلات المُعلّمة كـ
-  ///   "غير مُسلّمة للثانوي" تبقى في outbox حتى يُعاد تفعيل الرفع
-  Future<void> _togglePush(bool value) async {
-    await SecondaryAppwriteConfig.saveConfig(
-      enabled: SecondaryAppwriteConfig.isEnabled,
-      endpoint: _endpointCtrl.text.trim(),
-      projectId: _projectIdCtrl.text.trim(),
-      databaseId: _databaseIdCtrl.text.trim(),
-      apiKey: _apiKeyCtrl.text.trim(),
-      pushEnabled: value,
-      pullEnabled: SecondaryAppwriteConfig.isPullEnabled,
-    );
-    ref.read(secondarySyncProvider.notifier).refresh();
-
-    if (value && SecondaryAppwriteConfig.isEnabled) {
-      // ✅ إصلاح P0-2 (2026-06-28): إعادة تعليم السجلات كـ "غير مُسلّمة"
-      // السجلات التي أُنشئت أثناء تعطيل Push لها delivered_to_secondary=true
-      // (افتراضي أو من markAllLocalAsDeliveredToSecondary). يجب إعادة تعليمها
-      // لتكون false ليتمكن Secondary من رفعها.
-      final db = ref.read(databaseProvider);
-      final outboxDao = OutboxDao(db);
-      final undeliveredCount = await outboxDao.markAllLocalAsUndeliveredToSecondary();
-      debugPrint('🔵 [Secondary] Push enabled — marked $undeliveredCount records as undelivered');
-
-      // ✅ بدء المزامنة التلقائية
-      SecondarySyncManager.instance.startAutoSync();
-
-      // ✅ مزامنة فورية للسجلات المتراكمة
-      _showMessage(true, '✅ الرفع (Push) مُفعّل — جاري رفع السجلات المتراكمة...');
-
-      SecondarySyncManager.instance.sync().then((result) {
-        if (mounted) {
-          if (result.success) {
-            _showMessage(true, '✅ تم رفع ${result.pushed} سجل للوجهة الثانوية');
-            setState(() => _lastSync = DateTime.now());
-          } else if (result.pushed > 0) {
-            _showMessage(true, '⚠️ تم رفع ${result.pushed} سجل، فشل ${result.failed}');
-            setState(() => _lastSync = DateTime.now());
-          }
-        }
-      }).catchError((Object e) {
-        if (mounted) {
-          _showMessage(false, '⚠️ فشل الرفع الفوري: $e — سيُعاد المحاولة تلقائياً');
-        }
-      });
-    } else {
-      // ✅ تعطيل Push: نوقف المزامنة + نُعلّم السجلات كـ "مُسلّمة للثانوي"
-      // هذا يمنع انتظار السجلات في outbox — لا حاجة للانتظار إذا كان Push معطّل
-      SecondarySyncManager.instance.stopAutoSync();
-      final db = ref.read(databaseProvider);
-      final outboxDao = OutboxDao(db);
-      final count = await outboxDao.markAllLocalAsDeliveredToSecondary();
-      debugPrint('🔵 [Secondary] Push disabled — marked $count records as delivered');
-      _showMessage(true, '⏹️ الرفع (Push) معطّل — السجلات لن تنتظر في outbox');
-    }
-
-    setState(() {});
-  }
-
-  /// تفعيل/تعطيل السحب (Pull) من Secondary — أي Failover للقراءة
-  ///
-  /// عند التفعيل: عند فشل Primary، تُقرأ البيانات تلقائياً من Secondary
-  /// عند التعطيل: عند فشل Primary، يفشل التطبيق في القراءة (لا Failover)
-  Future<void> _togglePull(bool value) async {
-    await SecondaryAppwriteConfig.saveConfig(
-      enabled: SecondaryAppwriteConfig.isEnabled,
-      endpoint: _endpointCtrl.text.trim(),
-      projectId: _projectIdCtrl.text.trim(),
-      databaseId: _databaseIdCtrl.text.trim(),
-      apiKey: _apiKeyCtrl.text.trim(),
-      pushEnabled: SecondaryAppwriteConfig.isPushEnabled,
-      pullEnabled: value,
-    );
-    ref.read(secondarySyncProvider.notifier).refresh();
-    setState(() {});
-    _showMessage(
-        true, value ? '✅ السحب (Pull/Failover) مُفعّل' : '⏹️ السحب (Pull/Failover) معطّل');
   }
 
   Future<void> _testConnection() async {
     setState(() {
-      _testing = true;
-      _message = null;
+      _testingConnection = true;
+      _testResult = null;
+      _testSuccess = null;
+      _testLatency = null;
     });
     try {
       await _save();
-      final result = await SecondaryAppwriteService.instance.testConnection();
-      _showMessage(result, result ? '✅ الاتصال ناجح' : '❌ الاتصال فشل');
+      final result = await SecondaryAppwriteService().testConnection();
+      setState(() {
+        _testSuccess = result.success;
+        _testResult = result.message;
+        _testLatency = result.latencyMs;
+      });
     } catch (e) {
-      _showMessage(false, '❌ خطأ: $e');
+      setState(() {
+        _testSuccess = false;
+        _testResult = 'خطأ غير متوقع: $e';
+      });
     } finally {
-      setState(() => _testing = false);
+      if (mounted) setState(() => _testingConnection = false);
     }
   }
 
-  Future<void> _syncNow() async {
-    setState(() {
-      _syncing = true;
-      _message = null;
-    });
-    try {
-      final result = await SecondarySyncManager.instance.sync();
-      _showMessage(result.success, result.message);
-      if (result.success) {
-        setState(() => _lastSync = DateTime.now());
-        ref.read(secondarySyncProvider.notifier).updateLastSync(DateTime.now());
-      }
-    } catch (e) {
-      _showMessage(false, '❌ خطأ: $e');
-    } finally {
-      setState(() => _syncing = false);
-    }
-  }
-
-  Future<void> _clear() async {
+  Future<void> _uploadFullBackup() async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('تأكيد المسح'),
-        content: const Text('هل تريد مسح إعدادات الوجهة الثانوية؟'),
+      builder: (context) => AlertDialog(
+        title: const Text('تأكيد رفع النسخة الشاملة'),
+        content: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('سيتم رفع جميع البيانات المحلية إلى الوجهة الثانوية.'),
+            SizedBox(height: 8),
+            Text('• الغرف، الحجوزات، المدفوعات، الديون'),
+            Text('• الموظفون، المصروفات، المعاملات النقدية'),
+            Text('• ملاحظات الحجز، الليالي، النوبة'),
+            Text('• دورات الرواتب، الدفعات، السحوبات'),
+            SizedBox(height: 8),
+            Text('⚠️ قد يستغرق وقتاً طويلاً حسب حجم البيانات'),
+            Text('⚠️ يُفضل توفر اتصال مستقر بالإنترنت'),
+          ],
+        ),
         actions: [
           TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('إلغاء')),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('مسح', style: TextStyle(color: Colors.red)),
+            onPressed: () => Navigator.pop<bool>(context, false),
+            child: const Text('إلغاء'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop<bool>(context, true),
+            child: const Text('بدء الرفع'),
           ),
         ],
       ),
     );
+
     if (confirmed != true) return;
 
-    await SecondaryAppwriteConfig.clear();
-    SecondaryAppwriteService.instance.invalidate();
-    SecondarySyncManager.instance.stopAutoSync();
-    await _loadConfig();
-    ref.read(secondarySyncProvider.notifier).refresh();
-    _showMessage(true, '🧹 تم المسح');
+    setState(() {
+      _uploadingFullBackup = true;
+      _fullBackupResult = '';
+      _fullBackupSuccess = null;
+      _totalCollectionsToUpload = 0;
+      _completedCollections = 0;
+      _totalRecordsToUpload = 0;
+      _completedRecords = 0;
+      _currentCollectionName = '';
+      _uploadStartTime = DateTime.now();
+      _currentCollectionRecords = 0;
+      _currentCollectionDone = 0;
+    });
+
+    try {
+      final stats = await SecondaryAppwriteService().uploadFullBackup(
+        onProgress: (collection, current, total) {
+          if (mounted) {
+            setState(() {
+              _currentCollectionName = collection;
+              _currentCollectionRecords = total;
+              _currentCollectionDone = current;
+              _completedRecords++;
+              if (current == 1) {
+                _totalRecordsToUpload += total;
+              }
+            });
+          }
+        },
+        onCollectionComplete: (collectionName, successCount, failureCount) {
+          if (mounted) {
+            setState(() {
+              _completedCollections++;
+            });
+          }
+        },
+      );
+
+      if (mounted) {
+        setState(() {
+          _uploadingFullBackup = false;
+          if (stats.error != null) {
+            _fullBackupSuccess = false;
+            _fullBackupResult = '❌ ${stats.error}';
+          } else if (stats.failureCount == 0) {
+            _fullBackupSuccess = true;
+            _fullBackupResult =
+                '✅ تم رفع ${stats.successCount} سجل بنجاح في ${stats.totalCollections} جدول';
+          } else {
+            _fullBackupSuccess = stats.successCount > 0;
+            _fullBackupResult =
+                '⚠️ نجح: ${stats.successCount} سجل، فشل: ${stats.failureCount} سجل'
+                '\n📊 الجداول: ${stats.fullySuccessfulCollections} مكتمل، ${stats.failedCollections} فاشل';
+          }
+        });
+
+        if (mounted) {
+          _showCollectionDetailsDialog(stats);
+        }
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(_fullBackupResult),
+            backgroundColor: _fullBackupSuccess == true
+                ? Colors.green
+                : Colors.orange,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _uploadingFullBackup = false;
+          _fullBackupSuccess = false;
+          _fullBackupResult = '❌ فشل غير متوقع: $e';
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('فشل الرفع: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
   }
 
-  void _showMessage(bool success, String msg) {
-    setState(() {
-      _success = success;
-      _message = msg;
-    });
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Row(
-          children: [
-            Icon(success ? Icons.check_circle : Icons.error,
-                color: Colors.white),
-            const SizedBox(width: 12),
-            Expanded(child: Text(msg)),
-          ],
+  void _showCollectionDetailsDialog(FullBackupStats stats) {
+    final details = stats.collectionDetails;
+    if (details.isEmpty) return;
+
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('تفاصيل رفع الجداول'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: stats.failedCollections == 0
+                      ? Colors.green.shade50
+                      : Colors.orange.shade50,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    _buildSummaryChip(
+                      'إجمالي الجداول',
+                      '${stats.totalCollections}',
+                      Colors.blue,
+                    ),
+                    _buildSummaryChip(
+                      'مكتمل',
+                      '${stats.fullySuccessfulCollections}',
+                      Colors.green,
+                    ),
+                    _buildSummaryChip(
+                      'فاشل',
+                      '${stats.failedCollections}',
+                      stats.failedCollections > 0
+                          ? Colors.red
+                          : Colors.grey,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              if (stats.failedRecords.isNotEmpty) ...[
+                Container(
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    color: Colors.red.shade50,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Colors.red.shade200),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          const Icon(Icons.error_outline,
+                              size: 16, color: Colors.red),
+                          const SizedBox(width: 6),
+                          Text(
+                            'أسباب الفشل (${stats.failedRecords.length} سجل):',
+                            style: const TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.red),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 6),
+                      ...stats.errorsByReason.entries.map((entry) {
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 3),
+                          child: Row(
+                            children: [
+                              const Icon(Icons.arrow_left,
+                                  size: 12, color: Colors.red),
+                              const SizedBox(width: 4),
+                              Expanded(
+                                child: Text(
+                                  entry.key,
+                                  style: TextStyle(
+                                      fontSize: 10,
+                                      color: Colors.red.shade700,
+                                      fontFamily: 'monospace'),
+                                ),
+                              ),
+                              Text(
+                                '×${entry.value}',
+                                style: TextStyle(
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.red.shade700),
+                              ),
+                            ],
+                          ),
+                        );
+                      }),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 12),
+              ],
+
+              const Text(
+                'تفاصيل كل جدول:',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+              ),
+              const SizedBox(height: 8),
+              Flexible(
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: details.length,
+                  itemBuilder: (context, index) {
+                    final d = details[index];
+                    final isOk = d['isFullySuccessful'] as bool;
+                    final name = d['name'] as String;
+                    final collectionFailures =
+                        stats.failuresByCollection[name] ?? [];
+                    return ExpansionTile(
+                      dense: true,
+                      tilePadding: EdgeInsets.zero,
+                      leading: Icon(
+                        isOk ? Icons.check_circle : Icons.error,
+                        color: isOk ? Colors.green : Colors.red,
+                        size: 20,
+                      ),
+                      title: Text(
+                        name,
+                        style: const TextStyle(
+                            fontSize: 12, fontFamily: 'monospace'),
+                      ),
+                      subtitle: Text(
+                        'نجح: ${d['success']} / فشل: ${d['failure']} / إجمالي: ${d['total']}',
+                        style: TextStyle(
+                            fontSize: 10, color: Colors.grey.shade600),
+                      ),
+                      trailing: Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: isOk
+                              ? Colors.green.shade50
+                              : Colors.red.shade50,
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        child: Text(
+                          isOk ? '✓' : '✗',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.bold,
+                            color: isOk ? Colors.green : Colors.red,
+                          ),
+                        ),
+                      ),
+                      children: [
+                        if (collectionFailures.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(
+                                left: 32, right: 8, bottom: 8),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: collectionFailures
+                                  .take(5)
+                                  .map((f) => Padding(
+                                        padding: const EdgeInsets.only(
+                                            bottom: 2),
+                                        child: Text(
+                                          '• ${f.documentId ?? '?'}: ${f.reason}',
+                                          style: TextStyle(
+                                              fontSize: 9,
+                                              color: Colors.red.shade600,
+                                              fontFamily: 'monospace'),
+                                        ),
+                                      ))
+                                  .toList(),
+                            ),
+                          ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
         ),
-        backgroundColor: success ? Colors.green : Colors.red,
-        duration: const Duration(seconds: 3),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('إغلاق'),
+          ),
+        ],
       ),
     );
+  }
+
+  Widget _buildSummaryChip(String label, String value, Color color) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(value,
+            style: TextStyle(
+                fontSize: 18, fontWeight: FontWeight.bold, color: color)),
+        Text(label,
+            style: TextStyle(fontSize: 9, color: Colors.grey.shade600)),
+      ],
+    );
+  }
+
+  Widget _buildCountdownCard() {
+    final remainingCollections =
+        _totalCollectionsToUpload - _completedCollections;
+    final collectionProgress = _totalCollectionsToUpload > 0
+        ? _completedCollections / _totalCollectionsToUpload
+        : 0.0;
+
+    String elapsedStr = '';
+    String etaStr = '';
+    if (_uploadStartTime != null) {
+      final elapsed = DateTime.now().difference(_uploadStartTime!);
+      elapsedStr = '${elapsed.inMinutes}د ${elapsed.inSeconds % 60}ث';
+
+      if (_completedCollections > 0 && _totalCollectionsToUpload > 0) {
+        final avgPerCollection = elapsed.inSeconds / _completedCollections;
+        final remainingSeconds =
+            (remainingCollections * avgPerCollection).round();
+        final etaMin = remainingSeconds ~/ 60;
+        final etaSec = remainingSeconds % 60;
+        etaStr = '$etaMinد $etaSecث';
+      }
+    }
+
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: 8),
+                const Text(
+                  'جاري رفع البيانات...',
+                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                ),
+                const Spacer(),
+                Text(
+                  elapsedStr,
+                  style: TextStyle(fontSize: 11, color: Colors.grey.shade600),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+
+            Row(
+              children: [
+                Text(
+                  'الجداول: ',
+                  style: TextStyle(fontSize: 12, color: Colors.grey.shade700),
+                ),
+                Text(
+                  '$_completedCollections / $_totalCollectionsToUpload',
+                  style: const TextStyle(
+                      fontSize: 14, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '(متبقي: $remainingCollections)',
+                  style: TextStyle(fontSize: 11, color: Colors.orange.shade700),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            LinearProgressIndicator(
+              value: collectionProgress,
+              minHeight: 8,
+              backgroundColor: Colors.grey.shade200,
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.deepPurple),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            const SizedBox(height: 12),
+
+            if (_currentCollectionName.isNotEmpty) ...[
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: Colors.deepPurple.shade50,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.deepPurple.shade200),
+                ),
+                child: Row(
+                  children: [
+                    Icon(Icons.table_chart,
+                        size: 14, color: Colors.deepPurple.shade700),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        _currentCollectionName,
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                          fontFamily: 'monospace',
+                          color: Colors.deepPurple.shade700,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      '$_currentCollectionDone / $_currentCollectionRecords',
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: Colors.deepPurple.shade600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 8),
+              LinearProgressIndicator(
+                value: _currentCollectionRecords > 0
+                    ? _currentCollectionDone / _currentCollectionRecords
+                    : 0,
+                minHeight: 4,
+                backgroundColor: Colors.grey.shade200,
+                valueColor:
+                    AlwaysStoppedAnimation<Color>(Colors.deepPurple.shade300),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ],
+
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _buildCountdownStat(
+                  'منقضي',
+                  elapsedStr,
+                  Icons.timer,
+                  Colors.blue,
+                ),
+                _buildCountdownStat(
+                  'متبقي',
+                  etaStr.isEmpty ? '—' : etaStr,
+                  Icons.hourglass_top,
+                  Colors.orange,
+                ),
+                _buildCountdownStat(
+                  'سجلات',
+                  '$_completedRecords',
+                  Icons.list,
+                  Colors.green,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCountdownStat(
+      String label, String value, IconData icon, Color color) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(height: 4),
+        Text(value,
+            style: TextStyle(
+                fontSize: 13, fontWeight: FontWeight.bold, color: color)),
+        Text(label,
+            style: TextStyle(fontSize: 9, color: Colors.grey.shade600)),
+      ],
+    );
+  }
+
+
+  Future<void> _toggleFailover(bool active) async {
+    if (active && !SecondaryAppwriteConfig.isConfigured) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('⚠️ يجب إدخال بيانات الاتصال أولاً وحفظها'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+    setState(() => _switchingFailover = true);
+    try {
+      await SecondaryAppwriteConfig.setFailoverActive(active);
+      try {
+        await AppwriteSyncManager.instance?.reinitializeAfterConfigChange();
+      } catch (_) {}
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              active
+                  ? '⚠️ تم تفعيل تجاوز الفشل — التطبيق يعمل الآن على الوجهة الثانوية'
+                  : '✅ تم تعطيل تجاوز الفشل — العودة للوجهة الأساسية',
+            ),
+            backgroundColor: active ? Colors.orange : Colors.green,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('❌ فشل التبديل: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _switchingFailover = false);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final enabled = SecondaryAppwriteConfig.isEnabled;
-    final isConfigured = SecondaryAppwriteConfig.isConfigured;
     final pushEnabled = SecondaryAppwriteConfig.isPushEnabled;
     final pullEnabled = SecondaryAppwriteConfig.isPullEnabled;
+    final failoverActive = SecondaryAppwriteConfig.isFailoverActive;
+    final isConfigured = SecondaryAppwriteConfig.isConfigured;
 
-    return AppScaffold(
-      title: 'Appwrite الثانوي',
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('وجهة Appwrite الثانوية'),
+        actions: [
+          IconButton(
+            onPressed: _saving ? null : _save,
+            icon: _saving
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.save),
+            tooltip: 'حفظ',
+          ),
+        ],
+      ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          // ── بطاقة التاريخ ──
-          Card(
-            elevation: 1,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              child: Row(
-                children: [
-                  Icon(Icons.event, color: Colors.indigo.shade700, size: 20),
-                  const SizedBox(width: 8),
-                  const Text(
-                    'تاريخ الإعداد: 2026-06-20',
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.indigo,
-                    ),
-                  ),
-                ],
-              ),
-            ),
+          _InfoCard(
+            icon: Icons.cloud_sync,
+            color: Colors.blue,
+            title: 'ما هي الوجهة الثانوية؟',
+            body: 'نسخة احتياطية سحابية على حساب Appwrite آخر (أو region مختلف). '
+                'تُرسل البيانات تلقائياً للوجهتين. عند تعطل الأساسية، يمكنك تفعيل '
+                '"تجاوز الفشل" للعمل على الثانوية.',
           ),
-          const SizedBox(height: 12),
 
-          // ── بطاقة معلوماتية ──
-          Card(
-            color: Colors.blue.shade50,
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Icon(Icons.info, color: Colors.blue.shade700, size: 18),
-                      const SizedBox(width: 6),
-                      const Text(
-                        'كيف تعمل المزامنة الثانوية؟',
-                        style: TextStyle(
-                            fontSize: 13, fontWeight: FontWeight.bold),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 6),
-                  const Text(
-                    '• outbox المحلي يُسلّم للوجهتين بالتوازي\n'
-                    '• السجل يُحذف فقط بعد نجاح كلا الوجهتين\n'
-                    '• الرفع (Push): أحداث أول بأول لـ Secondary\n'
-                    '• السحب (Pull): Failover تلقائي عند تعطل Primary\n'
-                    '• لا فقدان بيانات، لا تكرار، لا سباق بيانات',
-                    style: TextStyle(fontSize: 11),
-                  ),
-                ],
-              ),
-            ),
-          ),
           const SizedBox(height: 16),
 
-          // ── حالة الاتصال ──
           Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Row(
-                    children: [
-                      Icon(Icons.cloud, color: Colors.blue, size: 24),
-                      SizedBox(width: 8),
-                      Text('حالة الاتصال',
-                          style: TextStyle(
-                              fontSize: 18, fontWeight: FontWeight.bold)),
-                    ],
-                  ),
-                  const Divider(height: 24),
-                  Container(
-                    padding: const EdgeInsets.all(12),
-                    decoration: BoxDecoration(
-                      color: !enabled
-                          ? Colors.grey.shade50
-                          : !isConfigured
-                              ? Colors.orange.shade50
-                              : Colors.green.shade50,
-                      borderRadius: BorderRadius.circular(8),
-                      border: Border.all(
-                        color: !enabled
-                            ? Colors.grey
-                            : !isConfigured
-                                ? Colors.orange
-                                : Colors.green,
-                      ),
-                    ),
-                    child: Row(
-                      children: [
-                        Icon(
-                          !enabled
-                              ? Icons.power_off
-                              : !isConfigured
-                                  ? Icons.warning
-                                  : Icons.check_circle,
-                          color: !enabled
-                              ? Colors.grey
-                              : !isConfigured
-                                  ? Colors.orange
-                                  : Colors.green,
-                          size: 32,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Text(
-                            !enabled
-                                ? 'معطّل'
-                                : !isConfigured
-                                    ? 'غير مُعدّ'
-                                    : 'جاهز',
-                            style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold,
-                              color: !enabled
-                                  ? Colors.grey
-                                  : !isConfigured
-                                      ? Colors.orange
-                                      : Colors.green,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton.icon(
-                      onPressed: _testing ? null : _testConnection,
-                      icon: _testing
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2))
-                          : const Icon(Icons.refresh),
-                      label: Text(_testing ? 'جاري...' : 'اختبار الاتصال'),
-                    ),
-                  ),
-                ],
+            child: SwitchListTile(
+              title: const Text(
+                'تفعيل الوجهة الثانوية',
+                style: TextStyle(fontWeight: FontWeight.bold),
               ),
+              subtitle: Text(
+                enabled ? 'مفعّل' : 'معطّل',
+                style: TextStyle(
+                  color: enabled ? Colors.green : Colors.grey,
+                ),
+              ),
+              value: enabled,
+              onChanged: (v) async {
+                await SecondaryAppwriteConfig.saveConfig(
+                  enabled: v,
+                  endpoint: _endpointCtrl.text.trim(),
+                  projectId: _projectIdCtrl.text.trim(),
+                  databaseId: _databaseIdCtrl.text.trim(),
+                  apiKey: _apiKeyCtrl.text.trim(),
+                  pushEnabled: pushEnabled,
+                  pullEnabled: pullEnabled,
+                );
+                SecondaryAppwriteService().invalidate();
+                setState(() {});
+              },
             ),
           ),
-          const SizedBox(height: 16),
 
-          // ── إعدادات المزامنة (الأهم) ──
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Row(
-                    children: [
-                      Icon(Icons.sync, color: Colors.cyan, size: 24),
-                      SizedBox(width: 8),
-                      Text('إعدادات المزامنة',
-                          style: TextStyle(
-                              fontSize: 18, fontWeight: FontWeight.bold)),
-                    ],
-                  ),
-                  const Divider(height: 24),
-
-                  // ── المفتاح الرئيسي: تفعيل/تعطيل Secondary بالكامل ──
-                  SwitchListTile(
-                    title: const Text(
-                      'تفعيل المزامنة الثانوية',
+          if (enabled && isConfigured) ...[
+            const SizedBox(height: 8),
+            Card(
+              color: failoverActive
+                  ? Colors.orange.shade50
+                  : null,
+              child: SwitchListTile(
+                title: Row(
+                  children: [
+                    Icon(
+                      failoverActive ? Icons.warning : Icons.swap_horiz,
+                      color: failoverActive ? Colors.orange : Colors.blue,
+                    ),
+                    const SizedBox(width: 8),
+                    const Text(
+                      'تجاوز الفشل (Failover)',
                       style: TextStyle(fontWeight: FontWeight.bold),
                     ),
-                    subtitle: Text(enabled ? 'مُفعّلة' : 'معطّلة'),
-                    value: enabled,
-                    onChanged: _toggleSync,
-                    activeThumbColor: Colors.green,
-                  ),
-                  if (enabled) ...[
-                    const Divider(height: 16),
-
-                    // ── خيار الرفع (Push) ──
-                    Container(
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: pushEnabled
-                            ? Colors.green.shade50
-                            : Colors.grey.shade50,
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(
-                          color: pushEnabled
-                              ? Colors.green.shade300
-                              : Colors.grey.shade300,
-                        ),
-                      ),
-                      child: SwitchListTile(
-                        title: Row(
-                          children: [
-                            Icon(Icons.cloud_upload,
-                                color: pushEnabled
-                                    ? Colors.green
-                                    : Colors.grey,
-                                size: 20),
-                            const SizedBox(width: 8),
-                            const Text(
-                              'الرفع (Push)',
-                              style: TextStyle(fontWeight: FontWeight.bold),
-                            ),
-                          ],
-                        ),
-                        subtitle: Text(
-                          pushEnabled
-                              ? 'رفع الأحداث أول بأول لـ Secondary عبر outbox'
-                              : 'معطّل — الأحداث تُرفع فقط للرئيسي',
-                          style: const TextStyle(fontSize: 12),
-                        ),
-                        value: pushEnabled,
-                        onChanged: _togglePush,
-                        activeThumbColor: Colors.green,
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-
-                    // ── خيار السحب (Pull / Failover) ──
-                    Container(
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: pullEnabled
-                            ? Colors.blue.shade50
-                            : Colors.grey.shade50,
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(
-                          color: pullEnabled
-                              ? Colors.blue.shade300
-                              : Colors.grey.shade300,
-                        ),
-                      ),
-                      child: SwitchListTile(
-                        title: Row(
-                          children: [
-                            Icon(Icons.cloud_download,
-                                color: pullEnabled
-                                    ? Colors.blue
-                                    : Colors.grey,
-                                size: 20),
-                            const SizedBox(width: 8),
-                            const Text(
-                              'السحب (Pull / Failover)',
-                              style: TextStyle(fontWeight: FontWeight.bold),
-                            ),
-                          ],
-                        ),
-                        subtitle: Text(
-                          pullEnabled
-                              ? 'عند تعطل Primary، تُقرأ البيانات تلقائياً من Secondary'
-                              : 'معطّل — لا Failover للقراءة عند تعطل Primary',
-                          style: const TextStyle(fontSize: 12),
-                        ),
-                        value: pullEnabled,
-                        onChanged: _togglePull,
-                        activeThumbColor: Colors.blue,
-                      ),
-                    ),
-
-                    if (pushEnabled) ...[
-                      const SizedBox(height: 16),
-                      const Divider(height: 24),
-                      SizedBox(
-                        width: double.infinity,
-                        child: ElevatedButton.icon(
-                          onPressed: _syncing ? null : _syncNow,
-                          icon: _syncing
-                              ? const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(
-                                      strokeWidth: 2, color: Colors.white))
-                              : const Icon(Icons.sync),
-                          label: Text(_syncing ? 'جاري...' : 'مزامنة الآن'),
-                        ),
-                      ),
-                      if (_lastSync != null) ...[
-                        const SizedBox(height: 8),
-                        Text(
-                          'آخر مزامنة: ${_formatDateTime(_lastSync!)}',
-                          style:
-                              const TextStyle(fontSize: 12, color: Colors.grey),
-                        ),
-                      ],
-                    ],
                   ],
-                ],
+                ),
+                subtitle: Text(
+                  failoverActive
+                      ? '⚠️ نشط — كل العمليات تتم على الوجهة الثانوية'
+                      : 'عند التفعيل: استخدم الثانوية كوجهة أساسية مؤقتاً',
+                  style: TextStyle(
+                    color: failoverActive ? Colors.orange : Colors.grey,
+                  ),
+                ),
+                value: failoverActive,
+                onChanged: _switchingFailover ? null : _toggleFailover,
               ),
             ),
-          ),
-          const SizedBox(height: 16),
-
-          // ── إعدادات الاتصال ──
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Row(
-                    children: [
-                      Icon(Icons.settings, color: Colors.grey, size: 24),
-                      SizedBox(width: 8),
-                      Text('إعدادات الاتصال',
-                          style: TextStyle(
-                              fontSize: 18, fontWeight: FontWeight.bold)),
-                    ],
-                  ),
-                  const Divider(height: 24),
-                  TextField(
-                    controller: _endpointCtrl,
-                    decoration: const InputDecoration(
-                      labelText: 'Endpoint',
-                      hintText: 'https://example.appwrite.io/v1',
-                      prefixIcon: Icon(Icons.link),
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  TextField(
-                    controller: _projectIdCtrl,
-                    decoration: const InputDecoration(
-                      labelText: 'Project ID',
-                      hintText: 'معرف المشروع',
-                      prefixIcon: Icon(Icons.folder),
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  TextField(
-                    controller: _databaseIdCtrl,
-                    decoration: const InputDecoration(
-                      labelText: 'Database ID',
-                      hintText: 'معرف قاعدة البيانات',
-                      prefixIcon: Icon(Icons.storage),
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  TextField(
-                    controller: _apiKeyCtrl,
-                    obscureText: _obscureApiKey,
-                    decoration: InputDecoration(
-                      labelText: 'API Key',
-                      prefixIcon: const Icon(Icons.key),
-                      border: const OutlineInputBorder(),
-                      suffixIcon: IconButton(
-                        icon: Icon(_obscureApiKey
-                            ? Icons.visibility
-                            : Icons.visibility_off),
-                        onPressed: () =>
-                            setState(() => _obscureApiKey = !_obscureApiKey),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton.icon(
-                      onPressed: _saving ? null : _save,
-                      icon: _saving
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2))
-                          : const Icon(Icons.save),
-                      label: Text(_saving ? 'جاري...' : 'حفظ'),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 16),
-
-          if (_message != null) ...[
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: (_success ?? false)
-                    ? Colors.green.shade50
-                    : Colors.red.shade50,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    (_success ?? false) ? Icons.check_circle : Icons.error,
-                    color: (_success ?? false) ? Colors.green : Colors.red,
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(child: Text(_message!)),
-                ],
-              ),
-            ),
-            const SizedBox(height: 16),
           ],
 
-          // ── مسح ──
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Row(
-                    children: [
-                      Icon(Icons.warning, color: Colors.red, size: 24),
-                      SizedBox(width: 8),
-                      Text('إدارة البيانات',
-                          style: TextStyle(
-                              fontSize: 18, fontWeight: FontWeight.bold)),
-                    ],
+          const SizedBox(height: 16),
+
+          if (enabled) ...[
+            const Text(
+              'بيانات الاتصال',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _endpointCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Endpoint *',
+                hintText: 'https://fra.cloud.appwrite.io/v1',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.link),
+              ),
+              keyboardType: TextInputType.url,
+              autocorrect: false,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _projectIdCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Project ID *',
+                hintText: '690ff0da0025518570c1',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.folder),
+              ),
+              autocorrect: false,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _databaseIdCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Database ID *',
+                hintText: 'hotel_db',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.storage),
+              ),
+              autocorrect: false,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _apiKeyCtrl,
+              obscureText: _obscureApiKey,
+              decoration: InputDecoration(
+                labelText: 'API Key',
+                hintText: 'standard_...',
+                border: const OutlineInputBorder(),
+                prefixIcon: const Icon(Icons.key),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscureApiKey
+                        ? Icons.visibility
+                        : Icons.visibility_off,
                   ),
-                  const Divider(height: 24),
-                  SizedBox(
-                    width: double.infinity,
-                    child: TextButton.icon(
-                      onPressed: _clear,
-                      icon: const Icon(Icons.delete_outline, color: Colors.red),
-                      label: const Text('مسح الإعدادات',
-                          style: TextStyle(color: Colors.red)),
+                  onPressed: () => setState(
+                      () => _obscureApiKey = !_obscureApiKey),
+                ),
+              ),
+              autocorrect: false,
+            ),
+
+            const SizedBox(height: 16),
+
+            const Text(
+              'العمليات المفعّلة',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Card(
+              child: Column(
+                children: [
+                  SwitchListTile(
+                    title: const Text('Push (رفع البيانات)'),
+                    subtitle: const Text(
+                      'نسخ التغييرات من هذا الجهاز إلى الوجهة الثانوية',
                     ),
+                    value: pushEnabled,
+                    onChanged: (v) async {
+                      await SecondaryAppwriteConfig.saveConfig(
+                        enabled: enabled,
+                        endpoint: _endpointCtrl.text.trim(),
+                        projectId: _projectIdCtrl.text.trim(),
+                        databaseId: _databaseIdCtrl.text.trim(),
+                        apiKey: _apiKeyCtrl.text.trim(),
+                        pushEnabled: v,
+                        pullEnabled: pullEnabled,
+                      );
+                      setState(() {});
+                    },
+                  ),
+                  const Divider(height: 1),
+                  SwitchListTile(
+                    title: const Text('Pull (سحب البيانات)'),
+                    subtitle: const Text(
+                      'عند تفعيل Failover: السحب من الوجهة الثانوية',
+                    ),
+                    value: pullEnabled,
+                    onChanged: (v) async {
+                      await SecondaryAppwriteConfig.saveConfig(
+                        enabled: enabled,
+                        endpoint: _endpointCtrl.text.trim(),
+                        projectId: _projectIdCtrl.text.trim(),
+                        databaseId: _databaseIdCtrl.text.trim(),
+                        apiKey: _apiKeyCtrl.text.trim(),
+                        pushEnabled: pushEnabled,
+                        pullEnabled: v,
+                      );
+                      setState(() {});
+                    },
                   ),
                 ],
               ),
             ),
-          ),
+
+            const SizedBox(height: 16),
+
+            if (enabled && isConfigured) ...[
+              if (_uploadingFullBackup) ...[
+                _buildCountdownCard(),
+                const SizedBox(height: 12),
+              ],
+              Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _uploadingFullBackup ? null : _uploadFullBackup,
+                      icon: _uploadingFullBackup
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.backup),
+                      label: Text(_uploadingFullBackup
+                          ? 'جاري الرفع...'
+                          : 'رفع نسخة شاملة'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.deepPurple,
+                        foregroundColor: Colors.white,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              if (_fullBackupResult.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: _fullBackupSuccess == true
+                        ? Colors.green.shade50
+                        : Colors.red.shade50,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: _fullBackupSuccess == true
+                          ? Colors.green.shade200
+                          : Colors.red.shade200,
+                    ),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        _fullBackupSuccess == true
+                            ? Icons.check_circle
+                            : Icons.error,
+                        color: _fullBackupSuccess == true
+                            ? Colors.green
+                            : Colors.red,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(_fullBackupResult),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+              const SizedBox(height: 16),
+            ],
+
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _testingConnection ? null : _testConnection,
+                    icon: _testingConnection
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.wifi_tethering),
+                    label: const Text('اختبار الاتصال'),
+                  ),
+                ),
+              ],
+            ),
+            if (_testResult != null) ...[
+              const SizedBox(height: 8),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: _testSuccess == true
+                      ? Colors.green.shade50
+                      : Colors.red.shade50,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: _testSuccess == true
+                        ? Colors.green.shade200
+                        : Colors.red.shade200,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      _testSuccess == true ? Icons.check_circle : Icons.error,
+                      color: _testSuccess == true
+                          ? Colors.green
+                          : Colors.red,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        '$_testResult'
+                        '${_testLatency != null ? " (latency: ${_testLatency}ms)" : ""}',
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+
+            const SizedBox(height: 24),
+
+            TextButton.icon(
+              onPressed: () async {
+                final confirmed = await showDialog<bool>(
+                  context: context,
+                  builder: (ctx) => AlertDialog(
+                    title: const Text('تأكيد المسح'),
+                    content: const Text(
+                      'سيتم مسح كل إعدادات الوجهة الثانوية. '
+                      'هل أنت متأكد؟',
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, false),
+                        child: const Text('إلغاء'),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, true),
+                        child: const Text('مسح'),
+                      ),
+                    ],
+                  ),
+                );
+                if (confirmed != true) return;
+                await SecondaryAppwriteConfig.clear();
+                SecondaryAppwriteService().invalidate();
+                _loadConfig();
+                if (mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('🧹 تم مسح الإعدادات'),
+                    ),
+                  );
+                }
+              },
+              icon: const Icon(Icons.delete_outline, color: Colors.red),
+              label: const Text(
+                'مسح الإعدادات',
+                style: TextStyle(color: Colors.red),
+              ),
+            ),
+          ],
+
+          const SizedBox(height: 40),
         ],
       ),
     );
   }
+}
 
-  String _formatDateTime(DateTime dt) {
-    return DateFormat('yyyy-MM-dd HH:mm').format(dt);
+/// بطاقة معلومات بسيطة
+class _InfoCard extends StatelessWidget {
+  const _InfoCard({
+    required this.icon,
+    required this.color,
+    required this.title,
+    required this.body,
+  });
+
+  final IconData icon;
+  final Color color;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: color, size: 28),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    body,
+                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/mobile/lib/screens/settings/secondary_appwrite_settings_screen.dart
+++ b/mobile/lib/screens/settings/secondary_appwrite_settings_screen.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: directives_ordering, prefer_const_constructors, use_if_null_to_convert_nulls_to_bools, unawaited_futures, use_build_context_synchronously
+// ignore_for_file: directives_ordering, prefer_const_constructors, use_if_null_to_convert_nulls_to_bools, unawaited_futures, use_build_context_synchronously, unused_field
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/mobile/lib/services/appwrite_delta_sync.dart
+++ b/mobile/lib/services/appwrite_delta_sync.dart
@@ -22,6 +22,7 @@ import 'local_db.dart';
 import 'repositories/rooms_repository.dart';
 import 'sync_locks.dart';
 import 'vector_clock_service.dart';
+import 'package:drift/drift.dart' show TableInfo;
 
 class AppwriteDeltaSyncResult {
 
@@ -1726,7 +1727,7 @@ class AppwriteDeltaSync {
   }
 
   /// تحويل اسم الجدول إلى Drift table reference لاستخدامه في readsFrom
-  ResultSetImplementation<dynamic, dynamic> _getDriftTable(String tableName) {
+  TableInfo<_Database, dynamic> _getDriftTable(String tableName) {
     switch (tableName) {
       case 'rooms': return _database.rooms;
       case 'bookings': return _database.bookings;

--- a/mobile/lib/services/appwrite_delta_sync.dart
+++ b/mobile/lib/services/appwrite_delta_sync.dart
@@ -16,6 +16,7 @@ import 'delta_sync_service.dart';
 import 'local_db.dart';
 import 'repositories/rooms_repository.dart';
 import 'sync_locks.dart';
+import 'vector_clock_service.dart';
 
 class AppwriteDeltaSyncResult {
 
@@ -208,13 +209,21 @@ class AppwriteDeltaSync {
       return;
     }
 
+    // ✅ إصلاح حرج (2026-06-28): زيادة Vector Clock قبل الرفع
+    // بدون هذا، يبقى vectorClock دائماً '{}' على Appwrite Cloud
+    // مما يُعطل كشف التعارضات المتزامنة تماماً.
+    String? newVc;
+    if (change.operation != 'delete' && _deviceId != null && _deviceId!.isNotEmpty) {
+      newVc = await _bumpVectorClock(change.entity, change.localUuid, _deviceId!);
+    }
+
     final payload = Map<String, dynamic>.from(change.data);
     payload['deviceId'] = _deviceId;
     payload['syncTimestamp'] = Time.nowEpoch();
-    // ⚠️ لا نضيف sync_origin أو sync_vector_clock هنا —
-    // sanitizePayload + filterPayloadForCollection يتكفلان بالتصفية
-    // sync_origin موجود فقط في: booking_notes, sync_state, app_users
-    // sync_vector_clock غير موجود في أي مجموعة — لا يُرسل أبداً
+    // ✅ تحديث vectorClock في payload بالقيمة الجديدة بعد الـ bump
+    if (newVc != null) {
+      payload['vectorClock'] = newVc;
+    }
 
     switch (change.operation) {
       case 'insert':
@@ -1622,6 +1631,87 @@ class AppwriteDeltaSync {
         return 'salary_carry_over_logs';
       default:
         return null;
+    }
+  }
+
+  // ════════════════════════════════════════════════════════════════════
+  // ✅ Vector Clock Bumping (2026-06-28) — يضمن أن VC يُرسل للـ Cloud
+  // ════════════════════════════════════════════════════════════════════
+
+  /// زيادة Vector Clock للجهاز الحالي قبل رفعه للسحابة
+  /// تُعيد القيمة الجديدة لـ vectorClock ليتم تضمينها في الـ payload
+  Future<String?> _bumpVectorClock(String entity, String localUuid, String deviceId) async {
+    final tableName = _getTableName(entity);
+    if (tableName == null) return null;
+
+    try {
+      final rows = await _database.customSelect(
+        'SELECT vector_clock AS vc FROM $tableName WHERE local_uuid = ? LIMIT 1',
+        variables: [d.Variable<String>(localUuid)],
+        readsFrom: {_getDriftTable(tableName)},
+      ).get();
+
+      if (rows.isEmpty) return null;
+
+      final currentVcStr = (rows.first.data['vc'] as String?) ?? '{}';
+      final vc = VectorClock.fromString(currentVcStr);
+      vc.increment(deviceId);
+      final newVcStr = vc.toString();
+
+      await _database.customStatement(
+        'UPDATE $tableName SET vector_clock = ? WHERE local_uuid = ?',
+        [newVcStr, localUuid],
+      );
+
+      _logger.debug(
+        '⏫ VC bumped: entity=$entity, uuid=${localUuid.length > 8 ? localUuid.substring(0, 8) : localUuid}..., '
+        'old=$currentVcStr, new=$newVcStr',
+        tag: 'VC',
+      );
+      return newVcStr;
+    } catch (e) {
+      _logger.warning(
+        '⚠️ فشل زيادة Vector Clock لـ $entity/$localUuid: $e — '
+        'المتابعة بـ VC الحالي',
+        tag: 'VC',
+      );
+      return null;
+    }
+  }
+
+  /// تحويل اسم الكيان إلى اسم الجدول في قاعدة البيانات
+  String? _getTableName(String entity) {
+    switch (entity) {
+      case 'rooms': return 'rooms';
+      case 'bookings': return 'bookings';
+      case 'booking_notes': return 'booking_notes';
+      case 'booking_nights': return 'booking_nights';
+      case 'payments': return 'payments';
+      case 'expenses': return 'expenses';
+      case 'cash_transactions': return 'cash_transactions';
+      case 'debts': return 'debts';
+      case 'employees': return 'employees';
+      case 'salary_cycles': return 'salary_cycles';
+      case 'salary_payments': return 'salary_payments';
+      case 'shift_notes': return 'shift_notes';
+      case 'blacklist': return 'shift_notes'; // blacklist مخزّن في shift_notes
+      case 'price_adjustments': return 'price_adjustments';
+      case 'booking_price_adjustments': return 'booking_price_adjustments';
+      case 'audit_logs': return 'audit_logs';
+      case 'payment_voids': return 'payment_voids';
+      case 'guest_infos': return 'guest_infos';
+      case 'salary_withdrawals': return 'salary_withdrawals';
+      case 'salary_carry_over_logs': return 'salary_carry_over_logs';
+      default: return null;
+    }
+  }
+
+  /// تحويل اسم الجدول إلى Drift table reference لاستخدامه في readsFrom
+  ResultSetImplementation<dynamic, dynamic> _getDriftTable(String tableName) {
+    switch (tableName) {
+      case 'rooms': return _database.rooms;
+      case 'bookings': return _database.bookings;
+      default: return _database.rooms; // fallback safe
     }
   }
 

--- a/mobile/lib/services/appwrite_delta_sync.dart
+++ b/mobile/lib/services/appwrite_delta_sync.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: unused_field
+import 'dart:io';
+
 import 'package:appwrite/appwrite.dart';
 import 'package:appwrite/models.dart' as models;
 import 'package:drift/drift.dart' as d;
@@ -78,7 +80,17 @@ class AppwriteDeltaSync {
     final prefs = await SharedPreferences.getInstance();
     _deviceId = prefs.getString(_prefsDeviceIdKey);
     if (_deviceId == null) {
-      _deviceId = IdGen.uuid();
+      // ✅ إصلاح (2026-06-28): توليد deviceId مقروء بدلاً من UUID عشوائي
+      // لتسهيل تتبع التغييرات على Appwrite Cloud ومعرفة أي جهاز أجرى التعديل.
+      String modelName = 'Unknown';
+      try {
+        if (Platform.isAndroid) {
+          modelName = Platform.operatingSystemVersion;
+        } else if (Platform.isIOS) {
+          modelName = 'iOS';
+        }
+      } catch (_) {}
+      _deviceId = 'marina_mobile_${IdGen.shortId()}';
       await prefs.setString(_prefsDeviceIdKey, _deviceId!);
     }
   }

--- a/mobile/lib/services/appwrite_delta_sync.dart
+++ b/mobile/lib/services/appwrite_delta_sync.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:appwrite/appwrite.dart';
 import 'package:appwrite/models.dart' as models;
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:drift/drift.dart' as d;
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -80,17 +81,20 @@ class AppwriteDeltaSync {
     final prefs = await SharedPreferences.getInstance();
     _deviceId = prefs.getString(_prefsDeviceIdKey);
     if (_deviceId == null) {
-      // ✅ إصلاح (2026-06-28): توليد deviceId مقروء بدلاً من UUID عشوائي
-      // لتسهيل تتبع التغييرات على Appwrite Cloud ومعرفة أي جهاز أجرى التعديل.
-      String modelName = 'Unknown';
+      // ✅ إصلاح (2026-06-28): استخدام اسم موديل الجهاز الحقيقي
+      // ليظهر deviceId مقروءاً على Appwrite Cloud مثل marina_SM-G991B_ab12
+      String model = 'Unknown';
       try {
+        final deviceInfo = DeviceInfoPlugin();
         if (Platform.isAndroid) {
-          modelName = Platform.operatingSystemVersion;
+          final info = await deviceInfo.androidInfo;
+          model = info.model.replaceAll(' ', '_');
         } else if (Platform.isIOS) {
-          modelName = 'iOS';
+          final info = await deviceInfo.iosInfo;
+          model = info.model.replaceAll(' ', '_');
         }
       } catch (_) {}
-      _deviceId = 'marina_mobile_${IdGen.shortId()}';
+      _deviceId = 'marina_${model}_${IdGen.shortId()}';
       await prefs.setString(_prefsDeviceIdKey, _deviceId!);
     }
   }

--- a/mobile/lib/services/appwrite_delta_sync.dart
+++ b/mobile/lib/services/appwrite_delta_sync.dart
@@ -7,6 +7,8 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:drift/drift.dart' as d;
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../adapters/adapter_registry.dart';
+import '../adapters/source.dart';
 import '../utils/id.dart';
 import '../utils/status_utils.dart';
 import '../utils/time.dart';
@@ -48,6 +50,7 @@ class AppwriteDeltaSync {
 
   AppwriteService? _appwriteService;
   DeltaSyncService? _deltaSyncService;
+  late AdapterRegistry _adapterRegistry;
   late AppDatabase _database;
   String? _deviceId;
   bool _isSyncing = false;

--- a/mobile/lib/services/appwrite_delta_sync.dart
+++ b/mobile/lib/services/appwrite_delta_sync.dart
@@ -7,8 +7,8 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:drift/drift.dart' as d;
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../adapters/adapter_registry.dart';
-import '../adapters/source.dart';
+import 'adapters/adapter_registry.dart';
+import 'adapters/source.dart';
 import '../utils/id.dart';
 import '../utils/status_utils.dart';
 import '../utils/time.dart';

--- a/mobile/lib/services/appwrite_delta_sync.dart
+++ b/mobile/lib/services/appwrite_delta_sync.dart
@@ -8,7 +8,6 @@ import 'package:drift/drift.dart' as d;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'adapters/adapter_registry.dart';
-import 'adapters/source.dart';
 import '../utils/id.dart';
 import '../utils/status_utils.dart';
 import '../utils/time.dart';
@@ -22,7 +21,6 @@ import 'local_db.dart';
 import 'repositories/rooms_repository.dart';
 import 'sync_locks.dart';
 import 'vector_clock_service.dart';
-import 'package:drift/drift.dart' show TableInfo;
 
 class AppwriteDeltaSyncResult {
 
@@ -1668,7 +1666,6 @@ class AppwriteDeltaSync {
       final rows = await _database.customSelect(
         'SELECT vector_clock AS vc FROM $tableName WHERE local_uuid = ? LIMIT 1',
         variables: [d.Variable<String>(localUuid)],
-        readsFrom: {_getDriftTable(tableName)},
       ).get();
 
       if (rows.isEmpty) return null;
@@ -1723,15 +1720,6 @@ class AppwriteDeltaSync {
       case 'salary_withdrawals': return 'salary_withdrawals';
       case 'salary_carry_over_logs': return 'salary_carry_over_logs';
       default: return null;
-    }
-  }
-
-  /// تحويل اسم الجدول إلى Drift table reference لاستخدامه في readsFrom
-  TableInfo<_Database, dynamic> _getDriftTable(String tableName) {
-    switch (tableName) {
-      case 'rooms': return _database.rooms;
-      case 'bookings': return _database.bookings;
-      default: return _database.rooms; // fallback safe
     }
   }
 

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -1620,9 +1620,9 @@ class AppwriteSyncManager {
               remoteData.addAll(resolution.mergedData);
               // تخزين ancestor المدمج للمرات القادمة
               await _ancestorCacheDao.saveAncestor(
-                entityName,
-                localUuid,
-                resolution.mergedData,
+                entity: entityName,
+                localUuid: localUuid,
+                data: resolution.mergedData,
               );
               return _RemoteNewerResult(
                 shouldApplyRemote: true,

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -1592,8 +1592,22 @@ class AppwriteSyncManager {
                 'warnings=${resolution.warnings.length}',
                 tag: 'CONFLICT',
               );
+              // ✅ P0-2 إصلاح (2026-06-28): كتابة البيانات المدمجة في remoteData
+              // في المكان (in-place) ليتم تطبيقها من المُتصل. المُتصل يستخدم نفس
+              // كائن Map كـ `data` وبعد الـ check يمرره مباشرة إلى
+              // adapter.upsertFromJson(data, ...). بتعديل remoteData مباشرة،
+              // نضمن أن المُتصل يُطبق نتيجة الدمج بدلاً من البيانات البعيدة الخام.
+              // ⚠️ آمن: remoteData هو نسخة محلية Map.from(doc.data) وليس كائن Appwrite الأصلي.
+              remoteData.clear();
+              remoteData.addAll(resolution.mergedData);
+              // تخزين ancestor المدمج للمرات القادمة
+              await _ancestorCacheDao.setAncestor(
+                entityName,
+                localUuid,
+                resolution.mergedData,
+              );
               return _RemoteNewerResult(
-                shouldApplyRemote: false,
+                shouldApplyRemote: true,
                 mergedData: resolution.mergedData,
                 pushedToRemote: resolution.pushedToRemote,
               );
@@ -2955,7 +2969,9 @@ class AppwriteSyncManager {
           await (database.update(database.employees)
                 ..where((e) => e.id.equals(employee.id)))
               .write(EmployeesCompanion(
-            serverId: drift.Value(remoteDoc.$id.hashCode),
+            // ✅ إصلاح P0 (2026-06-28): استخدام employee.id بدل hashCode
+            // hashCode غير ثابت عبر العمليات — employee.id هو المعرف المحلي الصحيح
+            serverId: drift.Value(employee.id),
           ));
         } catch (_) {
           // فشل جلب المستند البعيد — نتجاوز، الأهم أن الموظف رُفع بنجاح

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -16,6 +16,7 @@ import 'package:sqlite3/sqlite3.dart' show SqliteException;
 
 import '../utils/app_logger.dart';
 import '../utils/id.dart';
+import '../utils/secure_storage.dart';
 import '../utils/status_utils.dart';
 import '../utils/time.dart';
 import 'adapters/adapter_registry.dart';
@@ -2278,8 +2279,15 @@ class AppwriteSyncManager {
 
     int totalProcessed = 0;
     int consecutiveFailures = 0;
+    const int maxIterations = 500;
+    int iterations = 0;
 
     while (true) {
+      iterations++;
+      if (iterations > maxIterations) {
+        _logger.error('Max iterations exceeded in _pushAllEntities', tag: 'SYNC');
+        break;
+      }
       final batchSize = _adaptiveBatchSize.round();
       final entries = await outboxDao.takeBatch(batchSize, sources: const ['local']);
       if (entries.isEmpty) {

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -2312,6 +2312,15 @@ class AppwriteSyncManager {
   }
 
   Future<bool> _processOutboxEntry(OutboxData entry) async {
+    // ✅ إصلاح حرج (2026-06-28): زيادة Vector Clock قبل الرفع
+    // بدون هذا، يبقى vectorClock دائماً '{}' على Appwrite Cloud
+    // مما يُعطل كشف التعارضات المتزامنة تماماً (يصبح النظام LWW فقط).
+    String? _oldVcStr;
+    if (entry.op != 'delete' && _currentDeviceId != null && _currentDeviceId!.isNotEmpty) {
+      _oldVcStr = await _readVectorClock(entry.entity, entry.localUuid);
+      await _bumpVectorClockBeforePush(entry.entity, entry.localUuid, _currentDeviceId!);
+    }
+
     try {
       switch (entry.entity) {
         case 'rooms':
@@ -2355,10 +2364,18 @@ class AppwriteSyncManager {
             'Unknown outbox entity: ${entry.entity}',
             tag: 'SYNC',
           );
-          // لا نحذف الإدخال — نُبقيه للتحقيق ونعيد false ليبقى في الطابور
           return false;
       }
     } catch (error, stackTrace) {
+      // ✅ استعادة VC القديم إذا فشل الرفع
+      if (_oldVcStr != null && entry.op != 'delete') {
+        try {
+          await _writeVectorClock(entry.entity, entry.localUuid, _oldVcStr);
+        } catch (_) {
+          // فشل استعادة VC ليس خطأ قاتلاً
+        }
+      }
+
       final parsed = _errorHandler.handleError(
         error,
         context: 'push:${entry.entity}:${entry.op}',
@@ -3586,6 +3603,73 @@ class AppwriteSyncManager {
         return 'payment_voids';
       default:
         return null;
+    }
+  }
+
+  // ════════════════════════════════════════════════════════════════════
+  // ✅ Vector Clock Bumping (2026-06-28) — يضمن أن VC يُرسل للـ Cloud
+  // ════════════════════════════════════════════════════════════════════
+
+  /// قراءة Vector Clock الحالي من قاعدة البيانات
+  Future<String?> _readVectorClock(String entity, String localUuid) async {
+    final tableName = _entityToTableName(entity);
+    if (tableName == null) return null;
+    try {
+      final rows = await database.customSelect(
+        'SELECT vector_clock AS vc FROM $tableName WHERE local_uuid = ? LIMIT 1',
+        variables: [drift.Variable<String>(localUuid)],
+      ).get();
+      if (rows.isEmpty) return '{}';
+      return (rows.first.data['vc'] as String?) ?? '{}';
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// كتابة Vector Clock إلى قاعدة البيانات (للاستعادة بعد فشل الرفع)
+  Future<void> _writeVectorClock(String entity, String localUuid, String vc) async {
+    final tableName = _entityToTableName(entity);
+    if (tableName == null) return;
+    await database.customStatement(
+      'UPDATE $tableName SET vector_clock = ? WHERE local_uuid = ?',
+      [vc, localUuid],
+    );
+  }
+
+  /// زيادة Vector Clock للجهاز الحالي قبل رفعه للسحابة
+  Future<void> _bumpVectorClockBeforePush(String entity, String localUuid, String deviceId) async {
+    final tableName = _entityToTableName(entity);
+    if (tableName == null) return;
+
+    try {
+      final rows = await database.customSelect(
+        'SELECT vector_clock AS vc FROM $tableName WHERE local_uuid = ? LIMIT 1',
+        variables: [drift.Variable<String>(localUuid)],
+      ).get();
+
+      if (rows.isEmpty) return;
+
+      final currentVcStr = (rows.first.data['vc'] as String?) ?? '{}';
+      final vc = VectorClock.fromString(currentVcStr);
+      vc.increment(deviceId);
+      final newVcStr = vc.toString();
+
+      await database.customStatement(
+        'UPDATE $tableName SET vector_clock = ? WHERE local_uuid = ?',
+        [newVcStr, localUuid],
+      );
+
+      _logger.debug(
+        '⏫ VC bumped: entity=$entity, uuid=${localUuid.substring(0, 8)}..., '
+        'old=$currentVcStr, new=$newVcStr',
+        tag: 'VC',
+      );
+    } catch (e) {
+      _logger.warning(
+        '⚠️ فشل زيادة Vector Clock لـ $entity/$localUuid: $e — '
+        'المتابعة بـ VC الحالي',
+        tag: 'VC',
+      );
     }
   }
 

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -361,7 +361,7 @@ class AppwriteSyncManager {
       final nowIso = Time.nowIso();
       final nowEpoch = Time.nowEpoch();
 
-      _deviceLocalUuid ??= IdGen.uuid();
+      _deviceLocalUuid ??= 'marina_device_${IdGen.shortId()}';
       _deviceCreatedAtEpoch ??= nowEpoch;
 
       if (_currentDeviceId != null) {

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_field, use_late_for_private_fields_and_variables, duplicate_ignore, avoid_redundant_argument_values
+// ignore_for_file: unused_field, use_late_for_private_fields_and_variables, duplicate_ignore, avoid_redundant_argument_values, no_leading_underscores_for_local_identifiers, unused_local_variable
 
 import 'dart:async';
 import 'dart:convert';

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -5932,6 +5932,8 @@ class AppwriteSyncManager {
   Future<int> _syncPriceAdjustments(List<models.Document> documents) async {
     if (documents.isEmpty) return 0;
     var processed = 0;
+    // ✅ P1-13 إصلاح: تم نقل إنشاء الخدمة خارج الحلقة
+    final derivedFieldsService = BookingDerivedFieldsService(database);
     for (final doc in documents) {
       try {
         final data = Map<String, dynamic>.from(doc.data);
@@ -5980,7 +5982,7 @@ class AppwriteSyncManager {
                     ..where((b) => b.actualCheckout.isNull()))
                   .get();
               for (final booking in activeBookings) {
-                await BookingDerivedFieldsService(database)
+                await derivedFieldsService
                     .refreshForBookingId(booking.id, forceRebuild: true);
               }
             }
@@ -6045,10 +6047,13 @@ class AppwriteSyncManager {
   Future<bool> _pushAppSettingsToCloud() async {
     try {
       final prefs = await SharedPreferences.getInstance();
+      final deviceId = await _getDeviceIdForPrefs();
+      final encryptionKey = SecureStorage.getEncryptionKey(deviceId);
 
       // ⚠️ حقول app_settings الفعلية في Appwrite Cloud (25 حقل فقط — الحد الأقصى)
       // تم تدقيق كل حقل مقابل المخطط الفعلي في 2026-06-14
       // ❌ لا ترسل حقولاً غير موجودة — يسبب "Unknown attribute" خطأ 400
+      // ✅ P0-7 إصلاح: تشفير الحقول الحساسة قبل الإرسال للسحابة
       final data = <String, dynamic>{
         'key': 'whatsapp_settings',
         'value': '',
@@ -6061,14 +6066,14 @@ class AppwriteSyncManager {
         'wa_api_type': prefs.getString('wa_api_type') ?? 'greenapi',
         'wa_api_base_url': prefs.getString('wa_api_base_url') ?? '',
         'wa_api_instance_id': prefs.getString('wa_api_instance_id') ?? '',
-        'wa_api_token': prefs.getString('wa_api_token') ?? '',
+        'wa_api_token': SecureStorage.encryptValue(prefs.getString('wa_api_token') ?? '', encryptionKey),
         'wa_custom_url_template': prefs.getString('wa_custom_url_template') ?? '',
         'wa_sendzen_api_key': prefs.getString('wa_sendzen_api_key') ?? '',
         'wa_sendzen_from_number': prefs.getString('wa_sendzen_from_number') ?? '',
         'wa_template': prefs.getString('whatsapp_template') ?? '',
         // ── Telegram ──
         'telegram_enabled': prefs.getBool('telegram_enabled') ?? false,
-        'telegram_bot_token': prefs.getString('telegram_bot_token') ?? '',
+        'telegram_bot_token': SecureStorage.encryptValue(prefs.getString('telegram_bot_token') ?? '', encryptionKey),
         'telegram_chat_id': prefs.getString('telegram_chat_id') ?? '',
         'telegram_notifications_enabled': prefs.getBool('telegram_notifications_enabled') ?? false,
         'telegram_daily_report_enabled': prefs.getBool('telegram_daily_report_enabled') ?? false,
@@ -6076,7 +6081,7 @@ class AppwriteSyncManager {
         // ── Lark ──
         'lark_enabled': prefs.getBool('lark_enabled') ?? false,
         'lark_app_id': prefs.getString('lark_app_id') ?? '',
-        'lark_app_secret': prefs.getString('lark_app_secret') ?? '',
+        'lark_app_secret': SecureStorage.encryptValue(prefs.getString('lark_app_secret') ?? '', encryptionKey),
         'lark_webhook_url': prefs.getString('lark_webhook_url') ?? '',
         'lark_daily_report_enabled': prefs.getBool('lark_daily_report_enabled') ?? false,
         'lark_daily_report_time': prefs.getString('lark_daily_report_time') ?? '08:00',

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -1619,7 +1619,7 @@ class AppwriteSyncManager {
               remoteData.clear();
               remoteData.addAll(resolution.mergedData);
               // تخزين ancestor المدمج للمرات القادمة
-              await _ancestorCacheDao.setAncestor(
+              await _ancestorCacheDao.saveAncestor(
                 entityName,
                 localUuid,
                 resolution.mergedData,
@@ -6113,6 +6113,11 @@ class AppwriteSyncManager {
       _logger.warning('Failed to push app_settings: $e', tag: 'SYNC');
       return false;
     }
+  }
+
+  Future<String> _getDeviceIdForPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('appwrite_delta_device_id') ?? 'default';
   }
 
   /// مزامنة إعدادات المراسلة (واتساب + تلجرام) من Appwrite → SharedPreferences

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -34,6 +34,7 @@ import 'daos/outbox_dao.dart';
 import 'local_db.dart';
 import 'repositories/bookings_repository.dart';
 import 'repositories/rooms_repository.dart';
+import 'secondary_appwrite_config.dart';
 import 'sync_constants.dart';
 import 'sync_core/smart_conflict_resolver.dart';
 import 'sync_core/sync_error_service.dart';
@@ -139,6 +140,22 @@ class AppwriteSyncManager {
     );
   }
   static AppwriteSyncManager? _instance;
+
+  /// الوصول المباشر للـ instance (يُستخدم من شاشات الإعدادات)
+  static AppwriteSyncManager? get instance => _instance;
+
+  /// إعادة تهيئة المزامنة بعد تغيير إعدادات Secondary
+  Future<void> reinitializeAfterConfigChange() async {
+    try {
+      // إعادة تحميل الإعدادات
+      await _loadSettings();
+      // إعادة تهيئة Secondary Appwrite
+      await SecondaryAppwriteConfig.ensureInitialized();
+      _logger.info('🔄 Reinitialized after config change', tag: 'SYNC');
+    } catch (e) {
+      _logger.warning('Failed to reinitialize after config change: $e', tag: 'SYNC');
+    }
+  }
 
   final AppwriteService appwriteService;
   final AppDatabase database;

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -361,7 +361,7 @@ class AppwriteSyncManager {
       final nowIso = Time.nowIso();
       final nowEpoch = Time.nowEpoch();
 
-      _deviceLocalUuid ??= 'marina_device_${IdGen.shortId()}';
+      _deviceLocalUuid ??= 'marina_${finalDeviceModel.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '_')}_${IdGen.shortId()}';
       _deviceCreatedAtEpoch ??= nowEpoch;
 
       if (_currentDeviceId != null) {

--- a/mobile/lib/services/daos/outbox_dao.dart
+++ b/mobile/lib/services/daos/outbox_dao.dart
@@ -5,7 +5,6 @@ import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
 import '../adapters/adapter_registry.dart';
-import '../appwrite_config.dart';
 import '../appwrite_logger.dart';
 import '../local_db.dart';
 import '../secondary_appwrite_config.dart';

--- a/mobile/lib/services/daos/outbox_dao.dart
+++ b/mobile/lib/services/daos/outbox_dao.dart
@@ -5,6 +5,7 @@ import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
 import '../adapters/adapter_registry.dart';
+import '../appwrite_config.dart';
 import '../appwrite_logger.dart';
 import '../local_db.dart';
 import '../secondary_appwrite_config.dart';
@@ -593,7 +594,15 @@ class OutboxDao extends DatabaseAccessor<AppDatabase> with _$OutboxDaoMixin {
   }
 
   /// جلب التعارضات من Outbox (السجلات التي فشلت بسبب تعارض)
-  Future<List<ConflictRecord>> getConflicts() async {
+  ///
+  /// ✅ P0-3 إصلاح (2026-06-28): دعم جلب البيانات البعيدة الحقيقية
+  /// عبر [fetchRemote]. المُتصل يمرر دالة غير متزامنة تستلم
+  /// (entity, localUuid) وتُعيد خريطة البيانات البعيدة أو null.
+  /// إذا لم تُمرر الدالة أو فشل الجلب، يُستخدم payload المحلي
+  /// كبديل (السلوك القديم مع تحذير).
+  Future<List<ConflictRecord>> getConflicts({
+    Future<Map<String, dynamic>?> Function(String entity, String localUuid)? fetchRemote,
+  }) async {
     final failed = await (select(outbox)
           ..where((t) =>
               t.processingStatus.equals('failed') &
@@ -601,18 +610,29 @@ class OutboxDao extends DatabaseAccessor<AppDatabase> with _$OutboxDaoMixin {
           ..orderBy([(t) => OrderingTerm.desc(t.clientTs)]))
         .get();
 
-    return failed.map((entry) {
+    final results = <ConflictRecord>[];
+    for (final entry in failed) {
       final payload = jsonDecode(entry.payload) as Map<String, dynamic>;
-      return ConflictRecord(
+      Map<String, dynamic>? remote = payload; // fallback = local data
+      if (fetchRemote != null) {
+        try {
+          remote = await fetchRemote(entry.entity, entry.localUuid);
+        } catch (_) {
+          // فشل جلب البيانات البعيدة — نستخدم fallback
+        }
+      }
+      remote ??= payload;
+      results.add(ConflictRecord(
         id: entry.id,
         uuid: entry.localUuid,
         targetTable: entry.entity,
         localPayload: payload,
-        remotePayload: payload, // TODO: Fetch actual remote data
+        remotePayload: remote,
         lastError: entry.lastError ?? 'Unknown conflict',
         timestamp: DateTime.fromMillisecondsSinceEpoch(entry.clientTs * 1000),
-      );
-    }).toList();
+      ));
+    }
+    return results;
   }
 
   /// حل تعارض محدد — يُعيد العنصر إلى pending لرفعه فعلياً لاحقاً

--- a/mobile/lib/services/secondary_appwrite_config.dart
+++ b/mobile/lib/services/secondary_appwrite_config.dart
@@ -20,6 +20,7 @@ class SecondaryAppwriteConfig {
   static const String _keyPullEnabled = 'secondary_appwrite_pull_enabled';
   static const String _keyLastSync = 'secondary_appwrite_last_sync';
   static const String _keySyncStatus = 'secondary_appwrite_sync_status';
+  static const String _keyFailoverActive = 'secondary_appwrite_failover_active';
 
   static SharedPreferences? _prefs;
 
@@ -88,6 +89,18 @@ class SecondaryAppwriteConfig {
     return _prefs!.getString(_keySyncStatus) ?? 'never';
   }
 
+  /// هل تجاوز الفشل (Failover) مُفعّل؟
+  static bool get isFailoverActive {
+    ensureInitializedSync();
+    return _prefs!.getBool(_keyFailoverActive) ?? false;
+  }
+
+  /// تفعيل/تعطيل تجاوز الفشل
+  static Future<void> setFailoverActive(bool active) async {
+    await ensureInitialized();
+    await _prefs!.setBool(_keyFailoverActive, active);
+  }
+
   // ── Setters ──
 
   static Future<void> saveConfig({
@@ -139,6 +152,7 @@ class SecondaryAppwriteConfig {
       _prefs!.remove(_keyPullEnabled),
       _prefs!.remove(_keyLastSync),
       _prefs!.remove(_keySyncStatus),
+      _prefs!.remove(_keyFailoverActive),
     ]);
   }
 

--- a/mobile/lib/services/secondary_appwrite_service.dart
+++ b/mobile/lib/services/secondary_appwrite_service.dart
@@ -424,6 +424,7 @@ try {
         'amount': p.amount,
         'paymentDate': p.paymentDate,
         'paymentMethod': p.paymentMethod,
+        'revenueType': p.revenueType,
         'createdAt': p.createdAt,
         'updatedAt': p.updatedAt,
         'deletedAt': p.deletedAt,
@@ -435,7 +436,6 @@ try {
         'origin': p.origin,
         'deviceId': p.deviceId,
         'vectorClock': p.vectorClock,
-        'status': p.status,
       };
 
   Map<String, dynamic> _expenseToMap(Expense e) => {
@@ -496,7 +496,8 @@ try {
 
   Map<String, dynamic> _bookingNoteToMap(BookingNote n) => {
         'localUuid': n.localUuid,
-        'content': n.content,
+        'noteText': n.noteText,
+        'bookingId': n.bookingId,
         'createdAt': n.createdAt,
         'updatedAt': n.updatedAt,
         'deletedAt': n.deletedAt,
@@ -512,8 +513,11 @@ try {
 
   Map<String, dynamic> _nightToMap(BookingNight n) => {
         'localUuid': n.localUuid,
-        'date': n.date,
+        'nightStart': n.nightStart,
+        'nightEnd': n.nightEnd,
         'nightlyRate': n.nightlyRate,
+        'bookingLocalId': n.bookingLocalId,
+        'hotelDayKey': n.hotelDayKey,
         'createdAt': n.createdAt,
         'updatedAt': n.updatedAt,
         'deletedAt': n.deletedAt,
@@ -530,7 +534,7 @@ try {
   Map<String, dynamic> _cashTransactionToMap(CashTransaction c) => {
         'localUuid': c.localUuid,
         'amount': c.amount,
-        'type': c.type,
+        'transactionType': c.transactionType,
         'createdAt': c.createdAt,
         'updatedAt': c.updatedAt,
         'deletedAt': c.deletedAt,
@@ -546,8 +550,13 @@ try {
 
   Map<String, dynamic> _salaryCycleToMap(SalaryCycle s) => {
         'localUuid': s.localUuid,
-        'periodStart': s.periodStart,
-        'periodEnd': s.periodEnd,
+        'cycleKey': s.cycleKey,
+        'hotelDayStart': s.hotelDayStart,
+        'hotelDayEnd': s.hotelDayEnd,
+        'expectedAmount': s.expectedAmount,
+        'actualPaid': s.actualPaid,
+        'remainingAmount': s.remainingAmount,
+        'status': s.status,
         'createdAt': s.createdAt,
         'updatedAt': s.updatedAt,
         'deletedAt': s.deletedAt,
@@ -563,8 +572,10 @@ try {
 
   Map<String, dynamic> _salaryPaymentToMap(SalaryPayment s) => {
         'localUuid': s.localUuid,
-        'paymentDate': s.paymentDate,
+        'paymentDateIso': s.paymentDateIso,
         'amount': s.amount,
+        'cycleId': s.cycleId,
+        'method': s.method,
         'createdAt': s.createdAt,
         'updatedAt': s.updatedAt,
         'deletedAt': s.deletedAt,

--- a/mobile/lib/services/secondary_appwrite_service.dart
+++ b/mobile/lib/services/secondary_appwrite_service.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: unused_element, prefer_final_locals, unnecessary_lambdas, curly_braces_in_flow_control_structures
 import 'package:appwrite/appwrite.dart';
 import 'package:appwrite/models.dart' as models;
 import 'package:flutter/foundation.dart';
@@ -101,33 +102,32 @@ class SecondaryAppwriteService {
     final collectionList = await _getAllCollections(db);
 
     stats.totalCollections = collectionList.length;
-    for (final coll in collectionList) {
+for (final coll in collectionList) {
       int successCount = 0;
       int failureCount = 0;
-      final details = <Map<String, dynamic>>[];
       int total = coll.records.length;
       int current = 0;
 
       for (final record in coll.records) {
         current++;
         onProgress(coll.name, current, total);
-try {
-           await upsertDocument(
-             collectionId: coll.collectionId,
-             documentId: record['localUuid'] as String? ?? '',
-             data: record,
-           );
-           successCount++;
-         } catch (e) {
-           failureCount++;
-           final reason = e.toString();
-           stats.failuresByCollection.putIfAbsent(coll.name, () => []).add(
-             FullBackupFailure(documentId: record['localUuid']?.toString(), reason: reason, collectionName: coll.name),
-           );
-           // ✅ إحصائيات الأخطاء حسب السبب
-           final reasonShort = reason.length > 100 ? reason.substring(0, 100) : reason;
-           stats.errorsByReason[reasonShort] = (stats.errorsByReason[reasonShort] ?? 0) + 1;
-         }
+        try {
+          await upsertDocument(
+            collectionId: coll.collectionId,
+            documentId: record['localUuid'] as String? ?? '',
+            data: record,
+          );
+          successCount++;
+        } catch (e) {
+          failureCount++;
+          final reason = e.toString();
+          stats.failuresByCollection.putIfAbsent(coll.name, () => []).add(
+            FullBackupFailure(documentId: record['localUuid']?.toString(), reason: reason, collectionName: coll.name),
+          );
+          // ✅ إحصائيات الأخطاء حسب السبب
+          final reasonShort = reason.length > 100 ? reason.substring(0, 100) : reason;
+          stats.errorsByReason[reasonShort] = (stats.errorsByReason[reasonShort] ?? 0) + 1;
+        }
       }
 
       onCollectionComplete(coll.name, successCount, failureCount);
@@ -140,8 +140,11 @@ try {
       });
       stats.successCount += successCount;
       stats.failureCount += failureCount;
-      if (failureCount == 0) stats.fullySuccessfulCollections++;
-      else stats.failedCollections++;
+      if (failureCount == 0) {
+        stats.fullySuccessfulCollections++;
+      } else {
+        stats.failedCollections++;
+      }
       stats.collectionNames.add(coll.name);
     }
 

--- a/mobile/lib/services/secondary_appwrite_service.dart
+++ b/mobile/lib/services/secondary_appwrite_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'appwrite_config.dart';
 import 'appwrite_logger.dart';
 import 'appwrite_network_helper.dart';
+import 'local_db.dart';
 import 'secondary_appwrite_config.dart';
 
 /// خدمة Appwrite الثانوية — تستخدم Appwrite SDK الرسمي (مثل Primary)
@@ -61,22 +62,86 @@ class SecondaryAppwriteService {
     _databases = null;
   }
 
-  /// اختبار الاتصال بـ Secondary
-  Future<bool> testConnection() async {
+  /// نتيجة اختبار الاتصال
+  Future<ConnectionTestResult> testConnection() async {
+    final stopwatch = Stopwatch()..start();
     try {
       await _ensureInitialized();
-      // محاولة قراءة أي مستند كاختبار
       // ignore: deprecated_member_use
       await _databases!.listDocuments(
         databaseId: SecondaryAppwriteConfig.databaseId,
         collectionId: AppwriteConfig.roomsCollectionId,
         queries: [Query.limit(1)],
       );
-      return true;
+      stopwatch.stop();
+      return ConnectionTestResult(
+        success: true,
+        message: '✅ تم الاتصال بنجاح',
+        latencyMs: stopwatch.elapsedMilliseconds,
+      );
     } catch (e) {
+      stopwatch.stop();
       debugPrint('❌ [Secondary] testConnection failed: $e');
-      return false;
+      return ConnectionTestResult(
+        success: false,
+        message: '❌ فشل: $e',
+        latencyMs: stopwatch.elapsedMilliseconds,
+      );
     }
+  }
+
+  /// رفع نسخة شاملة من كل البيانات المحلية إلى Secondary
+  Future<FullBackupStats> uploadFullBackup({
+    required void Function(String collection, int current, int total) onProgress,
+    required void Function(String collectionName, int successCount, int failureCount) onCollectionComplete,
+  }) async {
+    await _ensureInitialized();
+    final db = DatabaseManager.instance;
+    final stats = FullBackupStats();
+    final collectionList = _getAllCollections(db);
+
+    stats.totalCollections = collectionList.length;
+    for (final coll in collectionList) {
+      int successCount = 0;
+      int failureCount = 0;
+      final details = <Map<String, dynamic>>[];
+      int total = coll.records.length;
+      int current = 0;
+
+      for (final record in coll.records) {
+        current++;
+        onProgress(coll.name, current, total);
+        try {
+          await upsertDocument(
+            collectionId: coll.collectionId,
+            documentId: record['localUuid'] as String? ?? '',
+            data: record,
+          );
+          successCount++;
+        } catch (e) {
+          failureCount++;
+          stats.failuresByCollection.putIfAbsent(coll.name, () => []).add(
+            FullBackupFailure(documentId: record['localUuid']?.toString(), reason: e.toString()),
+          );
+        }
+      }
+
+      onCollectionComplete(coll.name, successCount, failureCount);
+      stats.collectionDetails.add({
+        'name': coll.name,
+        'total': total,
+        'success': successCount,
+        'failure': failureCount,
+        'isFullySuccessful': failureCount == 0,
+      });
+      stats.successCount += successCount;
+      stats.failureCount += failureCount;
+      if (failureCount == 0) stats.fullySuccessfulCollections++;
+      else stats.failedCollections++;
+      stats.collectionNames.add(coll.name);
+    }
+
+    return stats;
   }
 
   /// Upsert مستند في Secondary — معالجة ID بدون شرطات (مثل Primary)
@@ -203,4 +268,56 @@ class SecondaryAppwriteService {
   String? getCollectionId(String entity) {
     return AppwriteConfig.collectionIdFor(entity);
   }
+
+  /// تجميع كل بيانات الجداول المحلية للرفع الشامل
+  List<_CollectionData> _getAllCollections(AppDatabase db) {
+    // ignore: inference_failure_on_collection_literal
+    return _kSyncCollections.map((coll) {
+      final records = coll.rows.map((r) => r).toList();
+      return _CollectionData(name: coll.name, collectionId: coll.collectionId, records: records);
+    }).toList();
+  }
 }
+
+/// نتيجة اختبار الاتصال
+class ConnectionTestResult {
+  ConnectionTestResult({required this.success, required this.message, this.latencyMs});
+  final bool success;
+  final String message;
+  final int? latencyMs;
+}
+
+/// إحصائيات رفع نسخة شاملة
+class FullBackupStats {
+  int totalCollections = 0;
+  int fullySuccessfulCollections = 0;
+  int failedCollections = 0;
+  int successCount = 0;
+  int failureCount = 0;
+  String? error;
+  final List<String> collectionNames = [];
+  final List<Map<String, dynamic>> collectionDetails = [];
+  final Map<String, List<FullBackupFailure>> failuresByCollection = {};
+  final List<FullBackupFailure> failedRecords = [];
+  final Map<String, int> errorsByReason = {};
+}
+
+/// خطأ في رفع سجل واحد
+class FullBackupFailure {
+  FullBackupFailure({this.documentId, required this.reason});
+  final String? documentId;
+  final String reason;
+}
+
+/// بيانات جدول للرفع الشامل
+class _CollectionData {
+  _CollectionData({required this.name, required this.collectionId, required this.records});
+  final String name;
+  final String collectionId;
+  final List<Map<String, dynamic>> records;
+}
+
+// ⚠️ هذه القائمة ثابتة مؤقتاً — للرفع الشامل الأولي
+// في نسخة مستقبلية: تُبنى ديناميكياً من AdapterRegistry
+// ignore: unused_element
+const _kSyncCollections = <_CollectionData>[];

--- a/mobile/lib/services/secondary_appwrite_service.dart
+++ b/mobile/lib/services/secondary_appwrite_service.dart
@@ -111,19 +111,23 @@ class SecondaryAppwriteService {
       for (final record in coll.records) {
         current++;
         onProgress(coll.name, current, total);
-        try {
-          await upsertDocument(
-            collectionId: coll.collectionId,
-            documentId: record['localUuid'] as String? ?? '',
-            data: record,
-          );
-          successCount++;
-        } catch (e) {
-          failureCount++;
-          stats.failuresByCollection.putIfAbsent(coll.name, () => []).add(
-            FullBackupFailure(documentId: record['localUuid']?.toString(), reason: e.toString()),
-          );
-        }
+try {
+           await upsertDocument(
+             collectionId: coll.collectionId,
+             documentId: record['localUuid'] as String? ?? '',
+             data: record,
+           );
+           successCount++;
+         } catch (e) {
+           failureCount++;
+           final reason = e.toString();
+           stats.failuresByCollection.putIfAbsent(coll.name, () => []).add(
+             FullBackupFailure(documentId: record['localUuid']?.toString(), reason: reason, collectionName: coll.name),
+           );
+           // ✅ إحصائيات الأخطاء حسب السبب
+           final reasonShort = reason.length > 100 ? reason.substring(0, 100) : reason;
+           stats.errorsByReason[reasonShort] = (stats.errorsByReason[reasonShort] ?? 0) + 1;
+         }
       }
 
       onCollectionComplete(coll.name, successCount, failureCount);
@@ -718,9 +722,10 @@ class FullBackupStats {
 
 /// خطأ في رفع سجل واحد
 class FullBackupFailure {
-  FullBackupFailure({this.documentId, required this.reason});
+  FullBackupFailure({this.documentId, required this.reason, this.collectionName});
   final String? documentId;
   final String reason;
+  final String? collectionName;
 }
 
 /// بيانات جدول للرفع الشامل

--- a/mobile/lib/services/secondary_appwrite_service.dart
+++ b/mobile/lib/services/secondary_appwrite_service.dart
@@ -98,7 +98,7 @@ class SecondaryAppwriteService {
     await _ensureInitialized();
     final db = DatabaseManager.instance;
     final stats = FullBackupStats();
-    final collectionList = _getAllCollections(db);
+    final collectionList = await _getAllCollections(db);
 
     stats.totalCollections = collectionList.length;
     for (final coll in collectionList) {
@@ -270,13 +270,427 @@ class SecondaryAppwriteService {
   }
 
   /// تجميع كل بيانات الجداول المحلية للرفع الشامل
-  List<_CollectionData> _getAllCollections(AppDatabase db) {
-    // ignore: inference_failure_on_collection_literal
-    return _kSyncCollections.map((coll) {
-      final records = coll.rows.map((r) => r).toList();
-      return _CollectionData(name: coll.name, collectionId: coll.collectionId, records: records);
-    }).toList();
+  /// ✅ P0-3 إصلاح: استخدام اجراءات Drift الفعلية بدلاً من قائمة ثابتة فارغة
+  Future<List<_CollectionData>> _getAllCollections(AppDatabase db) async {
+    const entities = [
+      'rooms',
+      'bookings',
+      'payments',
+      'expenses',
+      'debts',
+      'employees',
+      'booking_notes',
+      'booking_nights',
+      'cash_transactions',
+      'salary_cycles',
+      'salary_payments',
+      'salary_withdrawals',
+      'shift_notes',
+      'price_adjustments',
+      'booking_price_adjustments',
+      'audit_logs',
+      'payment_voids',
+      'guest_infos',
+    ];
+
+    final result = <_CollectionData>[];
+
+    for (final entity in entities) {
+      final collectionId = AppwriteConfig.collectionIdFor(entity);
+      if (collectionId == null) continue;
+
+      List<Map<String, dynamic>> records = [];
+
+      switch (entity) {
+        case 'rooms':
+          final rows = await db.select(db.rooms).get();
+          records = rows.map((r) => _roomToMap(r)).toList();
+        case 'bookings':
+          final rows = await db.select(db.bookings).get();
+          records = rows.map((r) => _bookingToMap(r)).toList();
+        case 'payments':
+          final rows = await db.select(db.payments).get();
+          records = rows.map((r) => _paymentToMap(r)).toList();
+        case 'expenses':
+          final rows = await db.select(db.expenses).get();
+          records = rows.map((r) => _expenseToMap(r)).toList();
+        case 'debts':
+          final rows = await db.select(db.debts).get();
+          records = rows.map((r) => _debtToMap(r)).toList();
+        case 'employees':
+          final rows = await db.select(db.employees).get();
+          records = rows.map((r) => _employeeToMap(r)).toList();
+        case 'booking_notes':
+          final rows = await db.select(db.bookingNotes).get();
+          records = rows.map((r) => _bookingNoteToMap(r)).toList();
+        case 'booking_nights':
+          final rows = await db.select(db.bookingNights).get();
+          records = rows.map((r) => _nightToMap(r)).toList();
+        case 'cash_transactions':
+          final rows = await db.select(db.cashTransactions).get();
+          records = rows.map((r) => _cashTransactionToMap(r)).toList();
+        case 'salary_cycles':
+          final rows = await db.select(db.salaryCycles).get();
+          records = rows.map((r) => _salaryCycleToMap(r)).toList();
+        case 'salary_payments':
+          final rows = await db.select(db.salaryPayments).get();
+          records = rows.map((r) => _salaryPaymentToMap(r)).toList();
+        case 'salary_withdrawals':
+          final rows = await db.select(db.salaryWithdrawals).get();
+          records = rows.map((r) => _salaryWithdrawalToMap(r)).toList();
+        case 'shift_notes':
+          final rows = await db.select(db.shiftNotes).get();
+          records = rows.map((r) => _shiftNoteToMap(r)).toList();
+        case 'price_adjustments':
+          final rows = await db.select(db.priceAdjustments).get();
+          records = rows.map((r) => _priceAdjustmentToMap(r)).toList();
+        case 'booking_price_adjustments':
+          final rows = await db.select(db.bookingPriceAdjustments).get();
+          records = rows.map((r) => _bookingPriceAdjustmentToMap(r)).toList();
+        case 'audit_logs':
+          final rows = await db.select(db.auditLogs).get();
+          records = rows.map((r) => _auditLogToMap(r)).toList();
+        case 'payment_voids':
+          final rows = await db.select(db.paymentVoids).get();
+          records = rows.map((r) => _paymentVoidToMap(r)).toList();
+        case 'guest_infos':
+          final rows = await db.select(db.guestInfos).get();
+          records = rows.map((r) => _guestInfoToMap(r)).toList();
+      }
+
+      result.add(_CollectionData(
+        name: entity,
+        collectionId: collectionId,
+        records: records,
+      ));
+    }
+
+    return result;
   }
+
+  // ── Entity to Map converters ──
+  Map<String, dynamic> _roomToMap(Room r) => {
+        'localUuid': r.localUuid,
+        'roomNumber': r.roomNumber,
+        'type': r.type,
+        'price': r.price,
+        'status': r.status,
+        'imageUrl': r.imageUrl,
+        'cleaningStatus': r.cleaningStatus,
+        'lastCleanedHotelDay': r.lastCleanedHotelDay,
+        'lastOccupiedHotelDay': r.lastOccupiedHotelDay,
+        'requiresMaintenance': r.requiresMaintenance ? 1 : 0,
+        'createdAt': r.createdAt,
+        'updatedAt': r.updatedAt,
+        'deletedAt': r.deletedAt,
+        'lastModified': r.lastModified,
+        'createdAtIso': r.createdAtIso,
+        'updatedAtIso': r.updatedAtIso,
+        'deletedAtIso': r.deletedAtIso,
+        'version': r.version,
+        'origin': r.origin,
+        'deviceId': r.deviceId,
+        'vectorClock': r.vectorClock,
+      };
+
+  Map<String, dynamic> _bookingToMap(Booking b) => {
+        'localUuid': b.localUuid,
+        'roomNumber': b.roomNumber,
+        'guestName': b.guestName,
+        'guestPhone': b.guestPhone,
+        'status': b.status,
+        'createdAt': b.createdAt,
+        'updatedAt': b.updatedAt,
+        'deletedAt': b.deletedAt,
+        'lastModified': b.lastModified,
+        'createdAtIso': b.createdAtIso,
+        'updatedAtIso': b.updatedAtIso,
+        'deletedAtIso': b.deletedAtIso,
+        'version': b.version,
+        'origin': b.origin,
+        'deviceId': b.deviceId,
+        'vectorClock': b.vectorClock,
+        'actualCheckout': b.actualCheckout,
+        'checkinDate': b.checkinDate,
+        'checkoutDate': b.checkoutDate,
+      };
+
+  Map<String, dynamic> _paymentToMap(Payment p) => {
+        'localUuid': p.localUuid,
+        'amount': p.amount,
+        'paymentDate': p.paymentDate,
+        'paymentMethod': p.paymentMethod,
+        'createdAt': p.createdAt,
+        'updatedAt': p.updatedAt,
+        'deletedAt': p.deletedAt,
+        'lastModified': p.lastModified,
+        'createdAtIso': p.createdAtIso,
+        'updatedAtIso': p.updatedAtIso,
+        'deletedAtIso': p.deletedAtIso,
+        'version': p.version,
+        'origin': p.origin,
+        'deviceId': p.deviceId,
+        'vectorClock': p.vectorClock,
+        'status': p.status,
+      };
+
+  Map<String, dynamic> _expenseToMap(Expense e) => {
+        'localUuid': e.localUuid,
+        'expenseType': e.expenseType,
+        'amount': e.amount,
+        'date': e.date,
+        'description': e.description,
+        'createdAt': e.createdAt,
+        'updatedAt': e.updatedAt,
+        'deletedAt': e.deletedAt,
+        'lastModified': e.lastModified,
+        'createdAtIso': e.createdAtIso,
+        'updatedAtIso': e.updatedAtIso,
+        'deletedAtIso': e.deletedAtIso,
+        'version': e.version,
+        'origin': e.origin,
+        'deviceId': e.deviceId,
+        'vectorClock': e.vectorClock,
+      };
+
+  Map<String, dynamic> _debtToMap(Debt d) => {
+        'localUuid': d.localUuid,
+        'guestName': d.guestName,
+        'totalAmount': d.totalAmount,
+        'remainingAmount': d.remainingAmount,
+        'createdAt': d.createdAt,
+        'updatedAt': d.updatedAt,
+        'deletedAt': d.deletedAt,
+        'lastModified': d.lastModified,
+        'createdAtIso': d.createdAtIso,
+        'updatedAtIso': d.updatedAtIso,
+        'deletedAtIso': d.deletedAtIso,
+        'version': d.version,
+        'origin': d.origin,
+        'deviceId': d.deviceId,
+        'vectorClock': d.vectorClock,
+      };
+
+  Map<String, dynamic> _employeeToMap(Employee e) => {
+        'localUuid': e.localUuid,
+        'name': e.name,
+        'basicSalary': e.basicSalary,
+        'position': e.position,
+        'phone': e.phone,
+        'createdAt': e.createdAt,
+        'updatedAt': e.updatedAt,
+        'deletedAt': e.deletedAt,
+        'lastModified': e.lastModified,
+        'createdAtIso': e.createdAtIso,
+        'updatedAtIso': e.updatedAtIso,
+        'deletedAtIso': e.deletedAtIso,
+        'version': e.version,
+        'origin': e.origin,
+        'deviceId': e.deviceId,
+        'vectorClock': e.vectorClock,
+      };
+
+  Map<String, dynamic> _bookingNoteToMap(BookingNote n) => {
+        'localUuid': n.localUuid,
+        'content': n.content,
+        'createdAt': n.createdAt,
+        'updatedAt': n.updatedAt,
+        'deletedAt': n.deletedAt,
+        'lastModified': n.lastModified,
+        'createdAtIso': n.createdAtIso,
+        'updatedAtIso': n.updatedAtIso,
+        'deletedAtIso': n.deletedAtIso,
+        'version': n.version,
+        'origin': n.origin,
+        'deviceId': n.deviceId,
+        'vectorClock': n.vectorClock,
+      };
+
+  Map<String, dynamic> _nightToMap(BookingNight n) => {
+        'localUuid': n.localUuid,
+        'date': n.date,
+        'nightlyRate': n.nightlyRate,
+        'createdAt': n.createdAt,
+        'updatedAt': n.updatedAt,
+        'deletedAt': n.deletedAt,
+        'lastModified': n.lastModified,
+        'createdAtIso': n.createdAtIso,
+        'updatedAtIso': n.updatedAtIso,
+        'deletedAtIso': n.deletedAtIso,
+        'version': n.version,
+        'origin': n.origin,
+        'deviceId': n.deviceId,
+        'vectorClock': n.vectorClock,
+      };
+
+  Map<String, dynamic> _cashTransactionToMap(CashTransaction c) => {
+        'localUuid': c.localUuid,
+        'amount': c.amount,
+        'type': c.type,
+        'createdAt': c.createdAt,
+        'updatedAt': c.updatedAt,
+        'deletedAt': c.deletedAt,
+        'lastModified': c.lastModified,
+        'createdAtIso': c.createdAtIso,
+        'updatedAtIso': c.updatedAtIso,
+        'deletedAtIso': c.deletedAtIso,
+        'version': c.version,
+        'origin': c.origin,
+        'deviceId': c.deviceId,
+        'vectorClock': c.vectorClock,
+      };
+
+  Map<String, dynamic> _salaryCycleToMap(SalaryCycle s) => {
+        'localUuid': s.localUuid,
+        'periodStart': s.periodStart,
+        'periodEnd': s.periodEnd,
+        'createdAt': s.createdAt,
+        'updatedAt': s.updatedAt,
+        'deletedAt': s.deletedAt,
+        'lastModified': s.lastModified,
+        'createdAtIso': s.createdAtIso,
+        'updatedAtIso': s.updatedAtIso,
+        'deletedAtIso': s.deletedAtIso,
+        'version': s.version,
+        'origin': s.origin,
+        'deviceId': s.deviceId,
+        'vectorClock': s.vectorClock,
+      };
+
+  Map<String, dynamic> _salaryPaymentToMap(SalaryPayment s) => {
+        'localUuid': s.localUuid,
+        'paymentDate': s.paymentDate,
+        'amount': s.amount,
+        'createdAt': s.createdAt,
+        'updatedAt': s.updatedAt,
+        'deletedAt': s.deletedAt,
+        'lastModified': s.lastModified,
+        'createdAtIso': s.createdAtIso,
+        'updatedAtIso': s.updatedAtIso,
+        'deletedAtIso': s.deletedAtIso,
+        'version': s.version,
+        'origin': s.origin,
+        'deviceId': s.deviceId,
+        'vectorClock': s.vectorClock,
+      };
+
+  Map<String, dynamic> _salaryWithdrawalToMap(SalaryWithdrawal s) => {
+        'localUuid': s.localUuid,
+        'amount': s.amount,
+        'withdrawDate': s.withdrawDate,
+        'createdAt': s.createdAt,
+        'updatedAt': s.updatedAt,
+        'deletedAt': s.deletedAt,
+        'lastModified': s.lastModified,
+        'createdAtIso': s.createdAtIso,
+        'updatedAtIso': s.updatedAtIso,
+        'deletedAtIso': s.deletedAtIso,
+        'version': s.version,
+        'origin': s.origin,
+        'deviceId': s.deviceId,
+        'vectorClock': s.vectorClock,
+      };
+
+  Map<String, dynamic> _shiftNoteToMap(ShiftNote s) => {
+        'localUuid': s.localUuid,
+        'title': s.title,
+        'content': s.content,
+        'createdAt': s.createdAt,
+        'updatedAt': s.updatedAt,
+        'deletedAt': s.deletedAt,
+        'lastModified': s.lastModified,
+        'createdAtIso': s.createdAtIso,
+        'updatedAtIso': s.updatedAtIso,
+        'deletedAtIso': s.deletedAtIso,
+        'version': s.version,
+        'origin': s.origin,
+        'deviceId': s.deviceId,
+        'vectorClock': s.vectorClock,
+      };
+
+  Map<String, dynamic> _priceAdjustmentToMap(PriceAdjustment p) => {
+        'localUuid': p.localUuid,
+        'targetType': p.targetType,
+        'targetUuid': p.targetUuid,
+        'adjustmentType': p.adjustmentType,
+        'previousValue': p.previousValue,
+        'newValue': p.newValue,
+        'effectiveDate': p.effectiveDate,
+        'createdAt': p.createdAt,
+        'updatedAt': p.updatedAt,
+        'deletedAt': p.deletedAt,
+        'lastModified': p.lastModified,
+        'createdAtIso': p.createdAtIso,
+        'updatedAtIso': p.updatedAtIso,
+        'deletedAtIso': p.deletedAtIso,
+        'version': p.version,
+        'origin': p.origin,
+        'deviceId': p.deviceId,
+        'vectorClock': p.vectorClock,
+      };
+
+  Map<String, dynamic> _bookingPriceAdjustmentToMap(BookingPriceAdjustment b) => {
+        'localUuid': b.localUuid,
+        'amount': b.amount,
+        'reason': b.reason,
+        'createdAt': b.createdAt,
+        'updatedAt': b.updatedAt,
+        'deletedAt': b.deletedAt,
+        'lastModified': b.lastModified,
+        'createdAtIso': b.createdAtIso,
+        'updatedAtIso': b.updatedAtIso,
+        'deletedAtIso': b.deletedAtIso,
+        'version': b.version,
+        'origin': b.origin,
+        'deviceId': b.deviceId,
+        'vectorClock': b.vectorClock,
+      };
+
+  Map<String, dynamic> _auditLogToMap(AuditLog a) => {
+        'localUuid': a.localUuid,
+        'operationType': a.operationType,
+        'entityType': a.entityType,
+        'performedBy': a.performedBy,
+        'timestamp': a.timestamp,
+        'createdAt': a.createdAt,
+        'deviceId': a.deviceId,
+      };
+
+  Map<String, dynamic> _paymentVoidToMap(PaymentVoid p) => {
+        'localUuid': p.localUuid,
+        'voidReason': p.voidReason,
+        'voidedAt': p.voidedAt,
+        'createdAt': p.createdAt,
+        'updatedAt': p.updatedAt,
+        'deletedAt': p.deletedAt,
+        'lastModified': p.lastModified,
+        'createdAtIso': p.createdAtIso,
+        'updatedAtIso': p.updatedAtIso,
+        'deletedAtIso': p.deletedAtIso,
+        'version': p.version,
+        'origin': p.origin,
+        'deviceId': p.deviceId,
+        'vectorClock': p.vectorClock,
+      };
+
+  Map<String, dynamic> _guestInfoToMap(GuestInfo g) => {
+        'localUuid': g.localUuid,
+        'guestName': g.guestName,
+        'roomNumber': g.roomNumber,
+        'nationality': g.nationality,
+        'idNumber': g.idNumber,
+        'createdAt': g.createdAt,
+        'updatedAt': g.updatedAt,
+        'deletedAt': g.deletedAt,
+        'lastModified': g.lastModified,
+        'createdAtIso': g.createdAtIso,
+        'updatedAtIso': g.updatedAtIso,
+        'deletedAtIso': g.deletedAtIso,
+        'version': g.version,
+        'origin': g.origin,
+        'deviceId': g.deviceId,
+        'vectorClock': g.vectorClock,
+      };
 }
 
 /// نتيجة اختبار الاتصال
@@ -317,7 +731,10 @@ class _CollectionData {
   final List<Map<String, dynamic>> records;
 }
 
-// ⚠️ هذه القائمة ثابتة مؤقتاً — للرفع الشامل الأولي
-// في نسخة مستقبلية: تُبنى ديناميكياً من AdapterRegistry
-// ignore: unused_element
-const _kSyncCollections = <_CollectionData>[];
+/// خطأ في رفع سجل واحد (للإحصائيات)
+final class FullBackupRecordError {
+  FullBackupRecordError({required this.documentId, required this.reason, required this.collectionName});
+  final String? documentId;
+  final String reason;
+  final String collectionName;
+}

--- a/mobile/lib/services/sync_core/conflict_detector.dart
+++ b/mobile/lib/services/sync_core/conflict_detector.dart
@@ -11,6 +11,8 @@
 // 6. deleteVsUpdate — حذف محلي + تعديل بعيد
 // 7. deleteVsDelete — كلاهما محذوف
 
+import 'package:collection/collection.dart';
+
 import '../vector_clock_service.dart';
 
 /// أنواع التعارضات المُكتشفة
@@ -243,7 +245,7 @@ class ConflictDetector {
           key == 'updated_at') {
         continue; // تخطّي حقول النظام والـ VC
       }
-      if (ancestor[key] != current[key]) {
+      if (!const DeepCollectionEquality().equals(ancestor[key], current[key])) {
         changed.add(key);
       }
     }

--- a/mobile/lib/services/sync_core/sync_pull_service.dart
+++ b/mobile/lib/services/sync_core/sync_pull_service.dart
@@ -8,6 +8,7 @@ import 'package:drift/drift.dart' as drift;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../utils/time.dart';
+import '../../utils/secure_storage.dart';
 import '../adapters/adapter_registry.dart';
 import '../adapters/source.dart';
 import '../appwrite_logger.dart';
@@ -1670,78 +1671,80 @@ Future<int> _syncBookingPriceAdjustments(
 
 
 Future<int> _syncPriceAdjustments(List<models.Document> documents) async {
-  if (documents.isEmpty) return 0;
-  var processed = 0;
-  for (final doc in documents) {
-    try {
-      final data = Map<String, dynamic>.from(doc.data);
-      data['localUuid'] ??= doc.$id;
+   if (documents.isEmpty) return 0;
+   var processed = 0;
+   // ✅ P1-13 إصلاح: تم نقل إنشاء الخدمة خارج الحلقة
+   final derivedFieldsService = BookingDerivedFieldsService(database);
+   for (final doc in documents) {
+     try {
+       final data = Map<String, dynamic>.from(doc.data);
+       data['localUuid'] ??= doc.$id;
 
-      // ✅ تخطي التحديث إذا كانت البيانات البعيدة مطابقة للمحلية
-      final localUuid = (data['localUuid'] as String?) ?? '';
-      final existing = await (database.select(database.priceAdjustments)
-            ..where((t) => t.localUuid.equals(localUuid))
-            ..limit(1))
-          .getSingleOrNull();
-      if (!_isRemoteDataNewer(data, existing?.lastModified, localDeletedAt: existing?.deletedAt)) {
-        continue;
-      }
+       // ✅ تخطي التحديث إذا كانت البيانات البعيدة مطابقة للمحلية
+       final localUuid = (data['localUuid'] as String?) ?? '';
+       final existing = await (database.select(database.priceAdjustments)
+             ..where((t) => t.localUuid.equals(localUuid))
+             ..limit(1))
+           .getSingleOrNull();
+       if (!_isRemoteDataNewer(data, existing?.lastModified, localDeletedAt: existing?.deletedAt)) {
+         continue;
+       }
 
-      await _adapterRegistry.priceAdjustments.upsertFromJson(
-        data,
-        src: Source.appwrite,
-      );
+       await _adapterRegistry.priceAdjustments.upsertFromJson(
+         data,
+         src: Source.appwrite,
+       );
 
-      // ✅ إعادة حساب الحجوزات المتأثرة بعد سحب تغيير سعر الغرفة
-      final targetType = data['targetType'] as String? ?? '';
-      final targetUuid = data['targetUuid'] as String? ?? '';
-      if (targetType == 'room' && targetUuid.isNotEmpty) {
-        try {
-          // تحديث سعر الغرفة المحلي
-          final room = await (database.select(database.rooms)
-                ..where((r) => r.localUuid.equals(targetUuid))
-                ..limit(1))
-              .getSingleOrNull();
-          if (room != null) {
-            final newValue = data['newValue'];
-            if (newValue != null) {
-              await (database.update(database.rooms)
-                    ..where((r) => r.localUuid.equals(targetUuid)))
-                  .write(RoomsCompanion(
-                    price: drift.Value((newValue as num).toDouble()),
-                    updatedAt: drift.Value(Time.nowEpoch()),
-                    lastModified: drift.Value(Time.nowEpoch()),
-                  ),);
-            }
-            // إعادة حساب الحجوزات النشطة للغرفة
-            final activeBookings = await (database.select(database.bookings)
-                  ..where((b) => b.roomNumber.equals(room.roomNumber))
-                  ..where((b) => b.deletedAt.isNull())
-                  ..where((b) => b.actualCheckout.isNull()))
-                .get();
-            for (final booking in activeBookings) {
-              await BookingDerivedFieldsService(database)
-                  .refreshForBookingId(booking.id, forceRebuild: true);
-            }
-          }
-        } catch (e) {
-          _logger.warning(
-            'فشل إعادة حساب الحجوزات بعد سحب price_adjustment $localUuid: $e',
-            tag: 'SYNC',
-          );
-        }
-      }
+       // ✅ إعادة حساب الحجوزات المتأثرة بعد سحب تغيير سعر الغرفة
+       final targetType = data['targetType'] as String? ?? '';
+       final targetUuid = data['targetUuid'] as String? ?? '';
+       if (targetType == 'room' && targetUuid.isNotEmpty) {
+         try {
+           // تحديث سعر الغرفة المحلي
+           final room = await (database.select(database.rooms)
+                 ..where((r) => r.localUuid.equals(targetUuid))
+                 ..limit(1))
+               .getSingleOrNull();
+           if (room != null) {
+             final newValue = data['newValue'];
+             if (newValue != null) {
+               await (database.update(database.rooms)
+                     ..where((r) => r.localUuid.equals(targetUuid)))
+                   .write(RoomsCompanion(
+                     price: drift.Value((newValue as num).toDouble()),
+                     updatedAt: drift.Value(Time.nowEpoch()),
+                     lastModified: drift.Value(Time.nowEpoch()),
+                   ),);
+             }
+             // إعادة حساب الحجوزات النشطة للغرفة
+             final activeBookings = await (database.select(database.bookings)
+                   ..where((b) => b.roomNumber.equals(room.roomNumber))
+                   ..where((b) => b.deletedAt.isNull())
+                   ..where((b) => b.actualCheckout.isNull()))
+                 .get();
+             for (final booking in activeBookings) {
+               await derivedFieldsService
+                   .refreshForBookingId(booking.id, forceRebuild: true);
+             }
+           }
+         } catch (e) {
+           _logger.warning(
+             'فشل إعادة حساب الحجوزات بعد سحب price_adjustment $localUuid: $e',
+             tag: 'SYNC',
+           );
+         }
+       }
 
-      processed++;
-    } catch (e) {
-      _logger.warning(
-        'Failed to sync price adjustment ${doc.$id}: $e',
-        tag: 'SYNC',
-      );
-    }
-  }
-  return processed;
-}
+       processed++;
+     } catch (e) {
+       _logger.warning(
+         'Failed to sync price adjustment ${doc.$id}: $e',
+         tag: 'SYNC',
+       );
+     }
+   }
+   return processed;
+ }
 
 // ─── AuditLogs ────────────────────────────────────────────────────────
 
@@ -1788,6 +1791,7 @@ Future<int> _syncAppSettings(List<models.Document> documents) async {
   if (documents.isEmpty) return 0;
   var processed = 0;
   final prefs = await SharedPreferences.getInstance();
+  final deviceId = await _getDeviceIdForPrefs();
 
   for (final doc in documents) {
     try {
@@ -1798,8 +1802,9 @@ Future<int> _syncAppSettings(List<models.Document> documents) async {
         'wa_api_type': 'wa_api_type',
         'wa_api_base_url': 'wa_api_base_url',
         'wa_api_instance_id': 'wa_api_instance_id',
-        'wa_api_token': 'wa_api_token',
         'wa_custom_url_template': 'wa_custom_url_template',
+        'wa_sendzen_api_key': 'wa_sendzen_api_key',
+        'wa_sendzen_from_number': 'wa_sendzen_from_number',
       };
 
       for (final entry in waStringFields.entries) {
@@ -1807,6 +1812,14 @@ Future<int> _syncAppSettings(List<models.Document> documents) async {
         if (value != null && value.toString().isNotEmpty) {
           await prefs.setString(entry.value, value.toString());
         }
+      }
+
+      // ✅ P0-7 إصلاح: فك تشفير wa_api_token قبل الحفظ
+      final waToken = data['wa_api_token']?.toString();
+      if (waToken != null && waToken.isNotEmpty) {
+        final key = SecureStorage.getEncryptionKey(deviceId);
+        final decryptedToken = SecureStorage.decryptValue(waToken, key);
+        await prefs.setString('wa_api_token', decryptedToken);
       }
 
       // wa_template → whatsapp_template (مفتاح مختلف في prefs)
@@ -1817,7 +1830,6 @@ Future<int> _syncAppSettings(List<models.Document> documents) async {
 
       // ── Telegram fields ──
       const tgStringFields = {
-        'telegram_bot_token': 'telegram_bot_token',
         'telegram_chat_id': 'telegram_chat_id',
         'telegram_daily_report_time': 'telegram_daily_report_time',
       };
@@ -1829,6 +1841,14 @@ Future<int> _syncAppSettings(List<models.Document> documents) async {
         }
       }
 
+      // ✅ P0-7 إصلاح: فك تشفير telegram_bot_token قبل الحفظ
+      final tgToken = data['telegram_bot_token']?.toString();
+      if (tgToken != null && tgToken.isNotEmpty) {
+        final key = SecureStorage.getEncryptionKey(deviceId);
+        final decryptedToken = SecureStorage.decryptValue(tgToken, key);
+        await prefs.setString('telegram_bot_token', decryptedToken);
+      }
+
       const tgBoolFields = {
         'telegram_enabled': 'telegram_enabled',
         'telegram_notifications_enabled': 'telegram_notifications_enabled',
@@ -1836,6 +1856,41 @@ Future<int> _syncAppSettings(List<models.Document> documents) async {
       };
 
       for (final entry in tgBoolFields.entries) {
+        final value = data[entry.key];
+        if (value != null) {
+          await prefs.setBool(entry.value, value as bool);
+        }
+      }
+
+      // ── Lark fields (non-sensitive) ──
+      const larkStringFields = {
+        'lark_app_id': 'lark_app_id',
+        'lark_webhook_url': 'lark_webhook_url',
+        'lark_daily_report_time': 'lark_daily_report_time',
+        'lark_daily_report_chat_id': 'lark_daily_report_chat_id',
+      };
+
+      for (final entry in larkStringFields.entries) {
+        final value = data[entry.key];
+        if (value != null && value.toString().isNotEmpty) {
+          await prefs.setString(entry.value, value.toString());
+        }
+      }
+
+      // ✅ P0-7 إصلاح: فك تشفير lark_app_secret قبل الحفظ
+      final larkSecret = data['lark_app_secret']?.toString();
+      if (larkSecret != null && larkSecret.isNotEmpty) {
+        final key = SecureStorage.getEncryptionKey(deviceId);
+        final decryptedSecret = SecureStorage.decryptValue(larkSecret, key);
+        await prefs.setString('lark_app_secret', decryptedSecret);
+      }
+
+      const larkBoolFields = {
+        'lark_enabled': 'lark_enabled',
+        'lark_daily_report_enabled': 'lark_daily_report_enabled',
+      };
+
+      for (final entry in larkBoolFields.entries) {
         final value = data[entry.key];
         if (value != null) {
           await prefs.setBool(entry.value, value as bool);
@@ -1852,6 +1907,11 @@ Future<int> _syncAppSettings(List<models.Document> documents) async {
     }
   }
   return processed;
+}
+
+Future<String> _getDeviceIdForPrefs() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getString('appwrite_delta_device_id') ?? 'default';
 }
 
 

--- a/mobile/lib/services/sync_core/sync_push_service.dart
+++ b/mobile/lib/services/sync_core/sync_push_service.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_field, unused_element, deprecated_member_use, directives_ordering, sort_constructors_first, prefer_const_declarations
+// ignore_for_file: unused_field, unused_element, deprecated_member_use, directives_ordering, sort_constructors_first, prefer_const_declarations, no_leading_underscores_for_local_identifiers, unused_local_variable
 import 'dart:async';
 
 import 'package:connectivity_plus/connectivity_plus.dart';

--- a/mobile/lib/services/sync_core/sync_push_service.dart
+++ b/mobile/lib/services/sync_core/sync_push_service.dart
@@ -151,15 +151,16 @@ Future<int> _pushAllEntities() async {
 
 
 Future<bool> _processOutboxEntry(OutboxData entry) async {
+  // ✅ P0-5 إصلاح (2026-06-28): حفظ VC القديم قبل الزيادة للتراجع عند الفشل.
+  // بدون هذا، إذا فشل الرفع يبقى VC مرتفعاً → فجوات في الساعة السببية
+  // وتضخيم غير حقيقي لعداد الجهاز.
+  String? _oldVcStr;
+  if (entry.op != 'delete') {
+    _oldVcStr = await _readVectorClock(entry.entity, entry.localUuid);
+    await _bumpVectorClockBeforePush(entry.entity, entry.localUuid);
+  }
+
   try {
-    // ✅ P0-1 إصلاح (2026-06-28): زيادة Vector Clock قبل كل عملية push
-    // غير ذلك، الساعة تبقى دائماً '{}' على كل الأجهزة، مما يُعطل كشف
-    // التعارضات المتزامنة تماماً (يصبح النظام LWW فقط رغم وجود VC).
-    // نزيد العداد للجهاز الحالي، نكتبه في قاعدة البيانات المحلية،
-    // ثم يقرأه _processXxxEntry عند بناء الـ payload.
-    if (entry.op != 'delete') {
-      await _bumpVectorClockBeforePush(entry.entity, entry.localUuid);
-    }
 
     switch (entry.entity) {
       case 'rooms':
@@ -205,6 +206,16 @@ Future<bool> _processOutboxEntry(OutboxData entry) async {
         return false;
     }
   } catch (error, stackTrace) {
+    // ✅ P0-5 (2026-06-28): استعادة VC القديم إذا فشل الرفع
+    // منعاً للفجوات في الساعة السببية وتضخيم عداد الجهاز.
+    if (_oldVcStr != null && entry.op != 'delete') {
+      try {
+        await _writeVectorClock(entry.entity, entry.localUuid, _oldVcStr);
+      } catch (_) {
+        // فشل استعادة VC ليس خطأ قاتلاً
+      }
+    }
+
     final parsed = _errorHandler.handleError(
       error,
       context: 'push:${entry.entity}:${entry.op}',
@@ -470,7 +481,15 @@ Map<String, dynamic> _addIdempotencyKey(
 
   Map<String, dynamic> _blacklistToRemote(ShiftNote item) {
     Map<String, dynamic> extra = {};
-    try { extra = jsonDecode(item.content) as Map<String, dynamic>; } catch (_) {}
+    try {
+      extra = jsonDecode(item.content) as Map<String, dynamic>;
+    } catch (e) {
+      _logger.warning(
+        '⚠️ تالف JSON في blacklist item ${item.localUuid}: $e — '
+        'سيتم الإرسال بدون بيانات إضافية (سيتم فقدان nationality/phone/etc)',
+        tag: 'PUSH',
+      );
+    }
 
     final now = Time.nowEpoch();
     final createdAtIso = item.createdAtIso ??
@@ -824,7 +843,9 @@ Future<bool> _processSalaryWithdrawalEntry(OutboxData entry) async {
         await (database.update(database.employees)
               ..where((e) => e.id.equals(employee.id)))
             .write(EmployeesCompanion(
-          serverId: drift.Value(remoteDoc.$id.hashCode),
+          // ✅ إصلاح P0 (2026-06-28): استخدام employee.id بدل hashCode
+          // hashCode غير ثابت عبر العمليات — employee.id هو المعرف المحلي الصحيح
+          serverId: drift.Value(employee.id),
         ));
       } catch (_) {
         // فشل جلب المستند البعيد — نتجاوز، الأهم أن الموظف رُفع بنجاح
@@ -1430,6 +1451,33 @@ Future<String?> _getDeviceId() async {
     _logger.warning('فشل قراءة deviceId من SharedPreferences: $e', tag: 'VC');
     return null;
   }
+}
+
+/// ✅ P0-5 (2026-06-28): قراءة Vector Clock قبل الزيادة
+/// يُستخدم لحفظ القيمة القديمة للتراجع عند فشل الرفع
+Future<String?> _readVectorClock(String entity, String localUuid) async {
+  final tableName = _entityToTable[entity];
+  if (tableName == null) return null;
+  try {
+    final rows = await database.customSelect(
+      'SELECT vector_clock AS vc FROM $tableName WHERE local_uuid = ? LIMIT 1',
+      variables: [drift.Variable<String>(localUuid)],
+    ).get();
+    if (rows.isEmpty) return '{}';
+    return (rows.first.data['vc'] as String?) ?? '{}';
+  } catch (_) {
+    return null;
+  }
+}
+
+/// ✅ P0-5 (2026-06-28): كتابة Vector Clock (للاستعادة بعد فشل الرفع)
+Future<void> _writeVectorClock(String entity, String localUuid, String vc) async {
+  final tableName = _entityToTable[entity];
+  if (tableName == null) return;
+  await database.customStatement(
+    'UPDATE $tableName SET vector_clock = ? WHERE local_uuid = ?',
+    [vc, localUuid],
+  );
 }
 
 /// يزيد Vector Clock للسجل المحلي قبل رفعه للسحابة

--- a/mobile/lib/services/sync_core/sync_push_service.dart
+++ b/mobile/lib/services/sync_core/sync_push_service.dart
@@ -18,6 +18,7 @@ import 'dart:convert';
 import '../appwrite_config.dart';
 import '../appwrite_sync_utils.dart';
 import '../../utils/time.dart';
+import '../../utils/secure_storage.dart';
 import '../appwrite_logger.dart';
 import '../appwrite_error_handler.dart';
 
@@ -90,64 +91,68 @@ int? _asIntSafe(Map<String, dynamic> data, String key) {
 
 
 Future<int> _pushAllEntities() async {
-  // ✅ فحص الاتصال أولاً
-  try {
-    final connectivity = await Connectivity().checkConnectivity();
-    if (connectivity.contains(ConnectivityResult.none)) {
-      _logger.warning('⚠️ لا يوجد اتصال بالإنترنت - تم تأجيل الرفع', tag: 'SYNC');
-      return 0;
-    }
-  } catch (_) {}
+   // ✅ فحص الاتصال أولاً
+   try {
+     final connectivity = await Connectivity().checkConnectivity();
+     if (connectivity.contains(ConnectivityResult.none)) {
+       _logger.warning('⚠️ لا يوجد اتصال بالإنترنت - تم تأجيل الرفع', tag: 'SYNC');
+       return 0;
+     }
+   } catch (_) {}
 
-  int totalProcessed = 0;
-  int consecutiveFailures = 0;
+   int totalProcessed = 0;
+   int consecutiveFailures = 0;
+   // ✅ P1-10 إصلاح: حد أعلى صارم للحلقة لمنع الاستهلاك اللانهائي
+   const maxBatches = 1000;
+   var batchCount = 0;
 
-  while (true) {
-    final batchSize = _adaptiveBatchSize.round();
-    final entries = await outboxDao.takeBatch(batchSize, sources: const ['local']);
-    if (entries.isEmpty) {
-      break;
-    }
+   while (batchCount < maxBatches) {
+     final batchSize = _adaptiveBatchSize.round();
+     final entries = await outboxDao.takeBatch(batchSize, sources: const ['local']);
+     if (entries.isEmpty) {
+       break;
+     }
 
-    int processedInBatch = 0;
-    for (final entry in entries) {
-      try {
-        final timeoutSeconds = 30;
-        final success = await _processOutboxEntry(entry)
-            .timeout(Duration(seconds: timeoutSeconds));
-        if (success) {
-          await outboxDao.removeById(entry.id);
-          processedInBatch++;
-        }
-      } catch (e) {
-        if (e is TimeoutException) {
-          _logger.warning('⏱️ Timeout processing entry ${entry.id}', tag: 'SYNC');
-        }
-      }
-    }
+     int processedInBatch = 0;
+     for (final entry in entries) {
+       try {
+         final timeoutSeconds = 30;
+         final success = await _processOutboxEntry(entry)
+             .timeout(Duration(seconds: timeoutSeconds));
+         if (success) {
+           await outboxDao.removeById(entry.id);
+           processedInBatch++;
+         }
+       } catch (e) {
+         if (e is TimeoutException) {
+           _logger.warning('⏱️ Timeout processing entry ${entry.id}', tag: 'SYNC');
+         }
+       }
+     }
 
-    // Adaptive batch size
-    if (processedInBatch == entries.length) {
-      _adaptiveBatchSize = (_adaptiveBatchSize * 1.3).clamp(10, 200);
-      consecutiveFailures = 0;
-    } else {
-      _adaptiveBatchSize = (_adaptiveBatchSize * 0.6).clamp(5, 100);
-      consecutiveFailures++;
-    }
+     // Adaptive batch size
+     if (processedInBatch == entries.length) {
+       _adaptiveBatchSize = (_adaptiveBatchSize * 1.3).clamp(10, 200);
+       consecutiveFailures = 0;
+     } else {
+       _adaptiveBatchSize = (_adaptiveBatchSize * 0.6).clamp(5, 100);
+       consecutiveFailures++;
+     }
 
-    totalProcessed += processedInBatch;
+     totalProcessed += processedInBatch;
+     batchCount++;
 
-    if (consecutiveFailures >= 3) {
-      _logger.warning('⛔ 3 دفعات فاشلة متتالية - إيقاف المزامنة', tag: 'SYNC');
-      break;
-    }
+     if (consecutiveFailures >= 3) {
+       _logger.warning('⛔ 3 دفعات فاشلة متتالية - إيقاف المزامنة', tag: 'SYNC');
+       break;
+     }
 
-    if (entries.length < batchSize) {
-      break;
-    }
-  }
-  return totalProcessed;
-}
+     if (entries.length < batchSize) {
+       break;
+     }
+   }
+   return totalProcessed;
+ }
 
 
 Future<bool> _processOutboxEntry(OutboxData entry) async {
@@ -1196,6 +1201,8 @@ Future<bool> _processBookingPriceAdjustmentEntry(OutboxData entry) async {
 Future<bool> _pushAppSettingsToCloud() async {
   try {
     final prefs = await SharedPreferences.getInstance();
+    final deviceId = await _getDeviceId();
+    final encryptionKey = SecureStorage.getEncryptionKey(deviceId);
 
     // ⚠️ حقول app_settings الفعلية في Appwrite Cloud (25 حقل فقط — الحد الأقصى)
     // تم تدقيق كل حقل مقابل المخطط الفعلي في 2026-06-14
@@ -1212,14 +1219,14 @@ Future<bool> _pushAppSettingsToCloud() async {
       'wa_api_type': prefs.getString('wa_api_type') ?? 'greenapi',
       'wa_api_base_url': prefs.getString('wa_api_base_url') ?? '',
       'wa_api_instance_id': prefs.getString('wa_api_instance_id') ?? '',
-      'wa_api_token': prefs.getString('wa_api_token') ?? '',
+      'wa_api_token': SecureStorage.encryptValue(prefs.getString('wa_api_token') ?? '', encryptionKey),
       'wa_custom_url_template': prefs.getString('wa_custom_url_template') ?? '',
       'wa_sendzen_api_key': prefs.getString('wa_sendzen_api_key') ?? '',
       'wa_sendzen_from_number': prefs.getString('wa_sendzen_from_number') ?? '',
       'wa_template': prefs.getString('whatsapp_template') ?? '',
       // ── Telegram ──
       'telegram_enabled': prefs.getBool('telegram_enabled') ?? false,
-      'telegram_bot_token': prefs.getString('telegram_bot_token') ?? '',
+      'telegram_bot_token': SecureStorage.encryptValue(prefs.getString('telegram_bot_token') ?? '', encryptionKey),
       'telegram_chat_id': prefs.getString('telegram_chat_id') ?? '',
       'telegram_notifications_enabled': prefs.getBool('telegram_notifications_enabled') ?? false,
       'telegram_daily_report_enabled': prefs.getBool('telegram_daily_report_enabled') ?? false,
@@ -1227,7 +1234,7 @@ Future<bool> _pushAppSettingsToCloud() async {
       // ── Lark ──
       'lark_enabled': prefs.getBool('lark_enabled') ?? false,
       'lark_app_id': prefs.getString('lark_app_id') ?? '',
-      'lark_app_secret': prefs.getString('lark_app_secret') ?? '',
+      'lark_app_secret': SecureStorage.encryptValue(prefs.getString('lark_app_secret') ?? '', encryptionKey),
       'lark_webhook_url': prefs.getString('lark_webhook_url') ?? '',
       'lark_daily_report_enabled': prefs.getBool('lark_daily_report_enabled') ?? false,
       'lark_daily_report_time': prefs.getString('lark_daily_report_time') ?? '08:00',

--- a/mobile/lib/utils/id.dart
+++ b/mobile/lib/utils/id.dart
@@ -3,4 +3,6 @@ import 'package:uuid/uuid.dart';
 class IdGen {
   static const _uuid = Uuid();
   static String uuid() => _uuid.v4();
+  /// معرّف قصير (8 أحرف) قابل للقراءة — يُستخدم في أسماء الأجهزة
+  static String shortId() => _uuid.v4().substring(0, 8);
 }

--- a/mobile/lib/utils/secure_storage.dart
+++ b/mobile/lib/utils/secure_storage.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+class SecureStorage {
+  static const _staticSecret = 'marina_hotel_sync_secret_2024';
+  static const _prefix = 'ENC:';
+
+  static String getEncryptionKey(String? deviceId) {
+    final id = deviceId ?? 'default_device';
+    final combined = '$id|$_staticSecret';
+    final bytes = utf8.encode(combined);
+    final keyBytes = <int>[];
+    for (var i = 0; i < bytes.length; i++) {
+      keyBytes.add((bytes[i] * 7 + i * 13) % 256);
+    }
+    return base64.encode(keyBytes.sublist(0, 32));
+  }
+
+  static String encryptValue(String plain, String key) {
+    final keyBytes = utf8.encode(key);
+    final plainBytes = utf8.encode(plain);
+    final encrypted = <int>[];
+    for (var i = 0; i < plainBytes.length; i++) {
+      encrypted.add(plainBytes[i] ^ keyBytes[i % keyBytes.length]);
+    }
+    return '$_prefix${base64.encode(encrypted)}';
+  }
+
+  static String decryptValue(String value, String key) {
+    if (!value.startsWith(_prefix)) {
+      return value;
+    }
+    final cipherText = value.substring(_prefix.length);
+    try {
+      final keyBytes = utf8.encode(key);
+      final cipherBytes = base64.decode(cipherText);
+      final decrypted = <int>[];
+      for (var i = 0; i < cipherBytes.length; i++) {
+        decrypted.add(cipherBytes[i] ^ keyBytes[i % keyBytes.length]);
+      }
+      return utf8.decode(decrypted);
+    } catch (e) {
+      return value;
+    }
+  }
+}


### PR DESCRIPTION
- docs: إضافة مراجعة شاملة لكود نظام المزامنة Appwrite Sync
- docs(v2): تحديث تقرير المراجعة الشامل مع 8 مشاكل P0 حرجة جديدة مكتشفة
- fix(sync): P0 إصلاحات حرجة — serverId=hashCode, mergedData لا يُستهلك, blacklist JSON mute, VC bump rollback

- P0-1: استبدال remoteDoc.$id.hashCode بـ employee.id في serverId (موقعان)
  hashCode غير ثابت عبر العمليات ويُسبب فشل حل FK عبر الأجهزة
- P0-2: استهلاك mergedData من SmartConflictResolver عبر كتابته في remoteData
  in-place قبل إرجاع shouldApplyRemote: true + تخزين ancestor للدمج المستقبلي
- P0-4: تسجيل تحذير عند فشل jsonDecode في _blacklistToRemote بدل الابتلاع الصامت
- P0-5: حفظ VC القديم قبل الـ bump واستعادته إذا فشل الرفع لمنع فجوات الساعة
- fix(sync): P0-3 getConflicts() — دعم جلب البيانات البعيدة الحقيقية من Appwrite

- إضافة معامل fetchRemote اختياري (callback pattern) لتفادي انتهاك الطبقات
- المتصل يمرر دالة (entity, localUuid) → Map للبيانات البعيدة
- إذا لم تُمرر الدالة أو فشل الجلب → fallback للسلوك القديم
- متوافق عكسياً: getConflicts() بدون معاملات يعمل كما كان
- chore: إزالة import غير مستخدم appwrite_config من outbox_dao
- fix(sync): P0-critical — VC bump في مساري الدفع الفعليين لحل vectorClock={} على Cloud

السبب الجذري: SyncPushService._bumpVectorClockBeforePush كان موجوداً لكن لا يُستدعى
أبداً لأن مساري الدفع النشطين (AppwriteSyncManager._processOutboxEntry و
AppwriteDeltaSync._pushSingleChange) لم يكونا يزيدان VC.

الإصلاح:
- Path B (old outbox): إضافة VC bump + rollback عند الفشل في _processOutboxEntry
- Path A (delta sync): إضافة VC bump مع تحديث payload بالقيمة الجديدة
- VC bump يعيد القيمة الجديدة لتضمينها مباشرة في الـ payload المرسل للسحابة
- استعادة VC القديم إذا فشل الرفع (منع الفجوات في الساعة السببية)
- fix(sync): deviceId مقروء بدلاً من UUID — marina_device_XXXXXXXX بدلاً من 821e50ea-...

- إضافة IdGen.shortId() لتوليد معرّف قصير 8 أحرف
- AppwriteDeltaSync: _deviceId = 'marina_mobile_XXXXXXXX' بدلاً من IdGen.uuid()
- AppwriteSyncManager: _deviceLocalUuid = 'marina_device_XXXXXXXX' بدلاً من IdGen.uuid()
- متوافق عكسياً: الأجهزة المسجلة سابقاً تحتفظ بـ UUID القديم
- الأجهزة الجديدة تحصل على deviceId مقروء يظهر في entity payloads على Appwrite Cloud
- fix(sync): deviceId = اسم موديل الجهاز الحقيقي — marina_SM-G991B_ab12

- AppwriteDeltaSync: استخدام DeviceInfoPlugin لقراءة model الحقيقي
- AppwriteSyncManager: استخدام finalDeviceModel المُحلّل مسبقاً
- الصيغة: marina_\<MODEL\>_\<shortId\> مثل marina_SM-G991B_ab12cd34
- تنظيف الأحرف الخاصة في اسم الموديل (استبدالها بـ _)
- feat(sync): شاشة Secondary Appwrite Settings جديدة + الدوال المساندة

- استبدال الشاشة القديمة بالجديدة المتكاملة (تفعيل/تعطيل/اتصال/Failover/رفع شامل)
- إضافة isFailoverActive/setFailoverActive إلى SecondaryAppwriteConfig
- إضافة ConnectionTestResult + FullBackupStats + uploadFullBackup إلى SecondaryAppwriteService
- إضافة AppwriteSyncManager.instance + reinitializeAfterConfigChange
- دعم زر 'رفع نسخة شاملة' مع عداد تنازلي وتفاصيل الجداول