### PR TITLE
Consolidate WhatsApp/Telegram config_json and sync field types

### DIFF
--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -5967,20 +5967,10 @@ class AppwriteSyncManager {
   // ─── PaymentVoids ─────────────────────────────────────────────────────
 
   /// رفع كل الإعدادات المحلية من SharedPreferences → Appwrite
-  /// ✅ الخيار 2: مفاتيح app_settings النصّية (WhatsApp/Telegram) التي تُجمَّع
-  /// في حقل واحد `config_json` بدل أعمدة منفصلة، لتفادي حدّ حجم الصف في Appwrite.
-  /// تُستخدم في الرفع (تجميع) والسحب (تفكيك) معاً لضمان التماثل.
-  static const List<String> _appSettingsConfigKeys = [
-    'wa_api_type',
-    'wa_api_base_url',
-    'wa_api_instance_id',
-    'wa_api_token',
-    'wa_custom_url_template',
-    'wa_sendzen_api_key',
-    'wa_sendzen_from_number',
-    'telegram_bot_token',
-    'telegram_chat_id',
-  ];
+  /// ✅ الخيار 2: مفاتيح app_settings النصّية (WhatsApp/Telegram) مُجمَّعة في
+  /// `config_json` — الثابت المشترك معرّف في `AppwriteSyncUtils.appSettingsConfigKeys`
+  /// (DRY: مصدر وحيد يستخدمه Primary و Secondary معاً).
+  /// 🔒 لا يُضاف 'api_key' (ثغرة أمنية) ولا 'appwrite_log_level' (إعداد محلي).
 
   Future<bool> _pushAppSettingsToCloud() async {
     try {
@@ -6035,7 +6025,7 @@ class AppwriteSyncManager {
       // في Appwrite (app_settings كان يفشل بـ "Missing/Unknown attribute").
       // نُزيل المفاتيح الفردية من الحمولة ونضعها داخل config_json.
       final configMap = <String, dynamic>{};
-      for (final k in _appSettingsConfigKeys) {
+      for (final k in AppwriteSyncUtils.appSettingsConfigKeys) {
         if (data.containsKey(k)) {
           configMap[k] = data.remove(k);
         }
@@ -6125,15 +6115,17 @@ class AppwriteSyncManager {
         final data = Map<String, dynamic>.from(doc.data);
 
         // ✅ الخيار 2: فكّ config_json المُجمّع ودمج مفاتيحه في data قبل
-        // منطق الحقول أدناه — فيبقى ذلك المنطق دون تغيير (توافق خلفي: إن جاء
-        // المستند بأعمدة قديمة منفصلة نحترمها لأننا نستخدم putIfAbsent).
+        // منطق الحقول أدناه. config_json هو المصدر الجديد للحقيقة، لذا قيمه
+        // تُسبق (overwrite) أي أعمدة قديمة منفصلة قد تكون موجودة في المستند.
+        // التوافق الخلفي: إن لم يوجد config_json (مستند من عميل قديم)، يبقى
+        // data بأعمدته الأصلية دون تعديل — لأن الـ if block لا يُنفَّذ.
         final rawConfig = data['config_json'];
         if (rawConfig is String && rawConfig.isNotEmpty) {
           try {
             final decoded = jsonDecode(rawConfig);
             if (decoded is Map) {
               decoded.forEach((k, v) {
-                data.putIfAbsent(k.toString(), () => v);
+                data[k.toString()] = v;
               });
             }
           } catch (e) {

--- a/mobile/lib/services/appwrite_sync_manager.dart
+++ b/mobile/lib/services/appwrite_sync_manager.dart
@@ -5967,6 +5967,21 @@ class AppwriteSyncManager {
   // ─── PaymentVoids ─────────────────────────────────────────────────────
 
   /// رفع كل الإعدادات المحلية من SharedPreferences → Appwrite
+  /// ✅ الخيار 2: مفاتيح app_settings النصّية (WhatsApp/Telegram) التي تُجمَّع
+  /// في حقل واحد `config_json` بدل أعمدة منفصلة، لتفادي حدّ حجم الصف في Appwrite.
+  /// تُستخدم في الرفع (تجميع) والسحب (تفكيك) معاً لضمان التماثل.
+  static const List<String> _appSettingsConfigKeys = [
+    'wa_api_type',
+    'wa_api_base_url',
+    'wa_api_instance_id',
+    'wa_api_token',
+    'wa_custom_url_template',
+    'wa_sendzen_api_key',
+    'wa_sendzen_from_number',
+    'telegram_bot_token',
+    'telegram_chat_id',
+  ];
+
   Future<bool> _pushAppSettingsToCloud() async {
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -6014,6 +6029,18 @@ class AppwriteSyncManager {
         'lastModifiedEpoch': now,
         'syncTimestamp': now,
       };
+
+      // ✅ الخيار 2: تجميع مفاتيح WhatsApp/Telegram النصّية الحسّاسة في حقل
+      // JSON واحد (config_json) بدل أعمدة منفصلة — لتفادي تجاوز حدّ حجم الصف
+      // في Appwrite (app_settings كان يفشل بـ "Missing/Unknown attribute").
+      // نُزيل المفاتيح الفردية من الحمولة ونضعها داخل config_json.
+      final configMap = <String, dynamic>{};
+      for (final k in _appSettingsConfigKeys) {
+        if (data.containsKey(k)) {
+          configMap[k] = data.remove(k);
+        }
+      }
+      data['config_json'] = jsonEncode(configMap);
 
       const docId = 'whatsapp_settings';
       const collectionId = 'app_settings';
@@ -6095,7 +6122,27 @@ class AppwriteSyncManager {
 
     for (final doc in documents) {
       try {
-        final data = doc.data;
+        final data = Map<String, dynamic>.from(doc.data);
+
+        // ✅ الخيار 2: فكّ config_json المُجمّع ودمج مفاتيحه في data قبل
+        // منطق الحقول أدناه — فيبقى ذلك المنطق دون تغيير (توافق خلفي: إن جاء
+        // المستند بأعمدة قديمة منفصلة نحترمها لأننا نستخدم putIfAbsent).
+        final rawConfig = data['config_json'];
+        if (rawConfig is String && rawConfig.isNotEmpty) {
+          try {
+            final decoded = jsonDecode(rawConfig);
+            if (decoded is Map) {
+              decoded.forEach((k, v) {
+                data.putIfAbsent(k.toString(), () => v);
+              });
+            }
+          } catch (e) {
+            _logger.warning(
+              'app_settings: تعذّر فكّ config_json: $e',
+              tag: 'SYNC',
+            );
+          }
+        }
 
         // ── WhatsApp fields ──
         const waStringFields = {

--- a/mobile/lib/services/appwrite_sync_utils.dart
+++ b/mobile/lib/services/appwrite_sync_utils.dart
@@ -25,6 +25,8 @@ class AppwriteSyncUtils {
       'auto_backup_frequency',
       'auto_backup_time',
       'conflict_strategy',
+      // ✅ الخيار 2: مفاتيح WhatsApp/Telegram النصّية مُجمّعة في config_json
+      'config_json',
       'createdAt',
       'createdAtEpoch',
       'createdAtIso',

--- a/mobile/lib/services/appwrite_sync_utils.dart
+++ b/mobile/lib/services/appwrite_sync_utils.dart
@@ -2,6 +2,26 @@ import '../utils/hotel_date_helper.dart';
 
 /// فئة أدوات موحدة لمعالجة البيانات قبل إرسالها أو بعد سحبها من Appwrite
 class AppwriteSyncUtils {
+  // ══════════════════════════════════════════════════════════════════════════
+  // ✅ الخيار 2: مفاتيح app_settings النصّية (WhatsApp/Telegram) التي تُجمَّع
+  // في حقل واحد `config_json` بدل أعمدة منفصلة، لتفادي حدّ حجم الصف في Appwrite.
+  // تُستخدم في الرفع (تجميع) والسحب (تفكيك) معاً لضمان التماثل.
+  // ⚠️ مصدر وحيد للحقيقة — يجب استخدامه في Primary و Secondary معاً (DRY).
+  // 🔒 ملاحظة أمنية: لا تُضِف 'api_key' هنا — رفعه للسحابة يُخزّن مفتاح الوصول
+  //    داخل النظام الذي يحميه (ثغرة أمنية). ولا 'appwrite_log_level' (إعداد محلي).
+  // ══════════════════════════════════════════════════════════════════════════
+  static const List<String> appSettingsConfigKeys = [
+    'wa_api_type',
+    'wa_api_base_url',
+    'wa_api_instance_id',
+    'wa_api_token',
+    'wa_custom_url_template',
+    'wa_sendzen_api_key',
+    'wa_sendzen_from_number',
+    'telegram_bot_token',
+    'telegram_chat_id',
+  ];
+
   /// الحقول التي يجب تحويلها إلى أعداد صحيحة (بناءً على قيود Appwrite الحالية)
   /// ⚠️ تم التحديث بناءً على الجداول الفعلية (remainingAmount وسواها أصبحت double)
   /// - payment_voids.voidedAmount: integer على Cloud ✓ (المتبقي الوحيد)
@@ -16,11 +36,13 @@ class AppwriteSyncUtils {
   // ══════════════════════════════════════════════════════════════════════════
   static const Map<String, Set<String>> validFieldsPerCollection = {
     'app_settings': {
-      'api_key',
+      // ✅ الإصلاح: حذف 'api_key' (لا يُرفع للسحابة — ثغرة أمنية، ولا يُستخدم
+      //    في _appSettingsToMap أصلاً) و 'appwrite_log_level' (إعداد محلي فقط).
+      //    كلاهما محذوف من SCHEMA في unified_appwrite_setup.js — إبقاؤهما هنا
+      //    يُضلّل المُطوّر ويُخاطر بتمريرهما عبر _filterPayload في المستقبل.
       'appwrite_auto_sync_on_connect',
       'appwrite_log_console',
       'appwrite_log_file',
-      'appwrite_log_level',
       'appwrite_sync_interval',
       'auto_backup_frequency',
       'auto_backup_time',

--- a/mobile/lib/services/appwrite_sync_utils.dart
+++ b/mobile/lib/services/appwrite_sync_utils.dart
@@ -1394,8 +1394,9 @@ class AppwriteSyncUtils {
       'targetType': 'string',
       'targetUuid': 'string',
       'adjustmentType': 'string',
-      'previousValue': 'integer',
-      'newValue': 'integer',
+      // ✅ نوع مطابق للنشر الفعلي (double على الوجهتين)؛ المحوّل يحوّل double→int
+      'previousValue': 'double',
+      'newValue': 'double',
       'reason': 'string',
       'effectiveDate': 'string',
       'appliedBy': 'string',
@@ -1471,7 +1472,8 @@ class AppwriteSyncUtils {
       'timestamp': 'integer',
       'timestampIso': 'string',
       'isFinancial': 'boolean',
-      'amountImpact': 'integer',
+      // ✅ نوع مطابق للنشر الفعلي (double على الوجهتين)؛ المحوّل يحوّل double→int
+      'amountImpact': 'double',
       'action': 'string',
     },
     'payment_voids': {

--- a/mobile/lib/services/secondary_appwrite_service.dart
+++ b/mobile/lib/services/secondary_appwrite_service.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: unused_element, prefer_final_locals, unnecessary_lambdas, curly_braces_in_flow_control_structures
+import 'dart:convert';
 import 'package:appwrite/appwrite.dart';
 import 'package:appwrite/models.dart' as models;
 import 'package:flutter/foundation.dart';
@@ -503,7 +504,7 @@ for (final coll in collectionList) {
       final now = DateTime.now().millisecondsSinceEpoch;
       final deviceId = prefs.getString('appwrite_delta_device_id') ?? 'default';
 
-      return {
+      final map = <String, dynamic>{
         'localUuid': 'whatsapp_settings',
         'value': '',
         'hotel_name': prefs.getString('hotel_name') ?? 'فندق مارينا بلازا',
@@ -540,6 +541,29 @@ for (final coll in collectionList) {
         'syncTimestamp': now,
         'sync_origin': 'secondary_backup',
       };
+
+      // ✅ الخيار 2: تجميع مفاتيح WhatsApp/Telegram النصّية في config_json واحد
+      // (مطابق لـ Primary) لتفادي تجاوز حدّ حجم الصف في Appwrite.
+      const configKeys = [
+        'wa_api_type',
+        'wa_api_base_url',
+        'wa_api_instance_id',
+        'wa_api_token',
+        'wa_custom_url_template',
+        'wa_sendzen_api_key',
+        'wa_sendzen_from_number',
+        'telegram_bot_token',
+        'telegram_chat_id',
+      ];
+      final configMap = <String, dynamic>{};
+      for (final k in configKeys) {
+        if (map.containsKey(k)) {
+          configMap[k] = map.remove(k);
+        }
+      }
+      map['config_json'] = jsonEncode(configMap);
+
+      return map;
     }
 }
 

--- a/mobile/lib/services/secondary_appwrite_service.dart
+++ b/mobile/lib/services/secondary_appwrite_service.dart
@@ -544,19 +544,10 @@ for (final coll in collectionList) {
 
       // ✅ الخيار 2: تجميع مفاتيح WhatsApp/Telegram النصّية في config_json واحد
       // (مطابق لـ Primary) لتفادي تجاوز حدّ حجم الصف في Appwrite.
-      const configKeys = [
-        'wa_api_type',
-        'wa_api_base_url',
-        'wa_api_instance_id',
-        'wa_api_token',
-        'wa_custom_url_template',
-        'wa_sendzen_api_key',
-        'wa_sendzen_from_number',
-        'telegram_bot_token',
-        'telegram_chat_id',
-      ];
+      // ⚠️ نُعيد استخدام `AppwriteSyncUtils.appSettingsConfigKeys` (DRY) — مصدر
+      //    وحيد للقائمة بين Primary و Secondary لتفادي الانحراف مستقبلاً.
       final configMap = <String, dynamic>{};
-      for (final k in configKeys) {
+      for (final k in AppwriteSyncUtils.appSettingsConfigKeys) {
         if (map.containsKey(k)) {
           configMap[k] = map.remove(k);
         }

--- a/scripts/appwrite/unified_appwrite_setup.js
+++ b/scripts/appwrite/unified_appwrite_setup.js
@@ -59,6 +59,10 @@ const API_KEY = process.env.APPWRITE_API_KEY;
 // أعلام سطر الأوامر
 const ARGV = process.argv.slice(2);
 const VERIFY_ONLY = ARGV.includes('--verify');
+// إصلاح الأنواع: يحذف كل حقل نوعه الفعلي يختلف عن SCHEMA ويُعيد إنشاءه بالنوع
+// الصحيح (Appwrite لا يسمح بتغيير نوع سمة في مكانها). ⚠️ عملية هدمية: تُفقد قيم
+// ذلك العمود على السحابة وتُعاد من التخزين المحلي عند المزامنة التالية.
+const FIX_TYPES = ARGV.includes('--fix-types');
 const ONLY_ARG = ARGV.find((a) => a.startsWith('--only='));
 const ONLY = ONLY_ARG
   ? ONLY_ARG.replace('--only=', '').split(',').map((s) => s.trim()).filter(Boolean)
@@ -348,8 +352,10 @@ const SCHEMA = {
     targetType: 'string',
     targetUuid: 'string',
     adjustmentType: 'string',
-    previousValue: 'integer',
-    newValue: 'integer',
+    // ✅ متطابق مع النشر الفعلي على الوجهتين (double)؛ محوّل السحب يحوّل
+    // double→int بأمان (_asInt/.toInt) لعمود Drift الصحيح.
+    previousValue: 'double',
+    newValue: 'double',
     reason: 'string',
     effectiveDate: 'string',
     appliedBy: 'string',
@@ -391,7 +397,8 @@ const SCHEMA = {
     timestamp: 'integer',
     timestampIso: 'string',
     isFinancial: 'boolean',
-    amountImpact: 'integer',
+    // ✅ متطابق مع النشر الفعلي على الوجهتين (double)؛ محوّل السحب يحوّل double→int
+    amountImpact: 'double',
     action: 'string',
   }),
 
@@ -719,6 +726,7 @@ async function ensureStandardIndexes(collectionId, fields) {
 async function verify(targetCollections) {
   let missingCollections = 0;
   let missingAttributes = 0;
+  let typeMismatches = 0;
 
   for (const collectionId of targetCollections) {
     const wanted = SCHEMA[collectionId];
@@ -733,20 +741,102 @@ async function verify(targetCollections) {
       }
       throw e;
     }
-    const actualKeys = new Set(actual.attributes.map((a) => a.key));
-    const missing = Object.keys(wanted).filter((k) => !actualKeys.has(k));
-    if (missing.length === 0) {
-      console.log(`✅ ${collectionId}: كل الحقول موجودة (${Object.keys(wanted).length})`);
+    // خريطة الحقل الفعلي → نوعه، لمقارنة الوجود والنوع معاً.
+    const actualByKey = new Map(actual.attributes.map((a) => [a.key, a]));
+    const missing = Object.keys(wanted).filter((k) => !actualByKey.has(k));
+
+    // ✅ فحص تطابق الأنواع — الحقل الموجود يجب أن يكون بنفس النوع المطلوب.
+    // نوع Appwrite (a.type) أحد: string | integer | double | boolean، وهو
+    // نفس مفردات SCHEMA. عدم التطابق هو ما يُنتج خطأ "invalid type" وقت الرفع.
+    const mismatches = [];
+    for (const [key, wantType] of Object.entries(wanted)) {
+      const attr = actualByKey.get(key);
+      if (attr && attr.type !== wantType) {
+        mismatches.push(`${key}: فعلي=${attr.type} ≠ مطلوب=${wantType}`);
+      }
+    }
+
+    if (missing.length === 0 && mismatches.length === 0) {
+      console.log(`✅ ${collectionId}: كل الحقول موجودة وبأنواع متطابقة (${Object.keys(wanted).length})`);
     } else {
-      console.log(`⚠️  ${collectionId}: ناقص ${missing.length} حقل → ${missing.join(', ')}`);
-      missingAttributes += missing.length;
+      if (missing.length > 0) {
+        console.log(`⚠️  ${collectionId}: ناقص ${missing.length} حقل → ${missing.join(', ')}`);
+        missingAttributes += missing.length;
+      }
+      if (mismatches.length > 0) {
+        console.log(`❌ ${collectionId}: ${mismatches.length} عدم تطابق نوع → ${mismatches.join(' | ')}`);
+        typeMismatches += mismatches.length;
+      }
     }
   }
 
   console.log('\n══════════════════════════════════════════');
-  console.log(`ملخّص الفحص: مجموعات مفقودة=${missingCollections}, حقول مفقودة=${missingAttributes}`);
+  console.log(
+    `ملخّص الفحص: مجموعات مفقودة=${missingCollections}, ` +
+      `حقول مفقودة=${missingAttributes}, عدم تطابق الأنواع=${typeMismatches}`,
+  );
   console.log('══════════════════════════════════════════');
-  process.exit(missingCollections + missingAttributes > 0 ? 2 : 0);
+  process.exit(
+    missingCollections + missingAttributes + typeMismatches > 0 ? 2 : 0,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5.1) وضع إصلاح الأنواع (--fix-types): حذف كل حقل نوعه يختلف عن SCHEMA وإعادة
+//      إنشائه بالنوع الصحيح. ⚠️ هدمي — تُفقد قيم العمود على السحابة (تُعاد محلياً).
+// ─────────────────────────────────────────────────────────────────────────────
+async function deleteAttributeAndWait(collectionId, key) {
+  try {
+    await databases.deleteAttribute(DATABASE_ID, collectionId, key);
+  } catch (e) {
+    if (e.code !== 404) throw e;
+  }
+  // حذف السمة غير فوري — ننتظر اختفاءها قبل إعادة الإنشاء بنفس المفتاح.
+  for (let i = 0; i < 30; i++) {
+    const coll = await databases.getCollection(DATABASE_ID, collectionId);
+    if (!coll.attributes.some((a) => a.key === key)) return;
+    await sleep(1000);
+  }
+  throw new Error(`لم يكتمل حذف السمة ${collectionId}.${key} خلال المهلة`);
+}
+
+async function fixTypes(targetCollections) {
+  let fixed = 0;
+  let failed = 0;
+  for (const collectionId of targetCollections) {
+    const wanted = SCHEMA[collectionId];
+    let actual;
+    try {
+      actual = await databases.getCollection(DATABASE_ID, collectionId);
+    } catch (e) {
+      if (e.code === 404) {
+        console.log(`❌ المجموعة مفقودة: ${collectionId}`);
+        continue;
+      }
+      throw e;
+    }
+    const byKey = new Map(actual.attributes.map((a) => [a.key, a]));
+    for (const [key, wantType] of Object.entries(wanted)) {
+      const attr = byKey.get(key);
+      if (attr && attr.type !== wantType) {
+        console.log(
+          `♻️  ${collectionId}.${key}: ${attr.type} → ${wantType} (حذف + إعادة إنشاء)`,
+        );
+        try {
+          await deleteAttributeAndWait(collectionId, key);
+          await ensureAttribute(collectionId, key, wantType);
+          fixed++;
+        } catch (e) {
+          console.log(`   ❌ فشل إصلاح ${key}: ${e.message || e}`);
+          failed++;
+        }
+      }
+    }
+  }
+  console.log('\n══════════════════════════════════════════');
+  console.log(`إصلاح الأنواع: مُصلَح=${fixed}, فشل=${failed}`);
+  console.log('══════════════════════════════════════════');
+  process.exit(failed > 0 ? 2 : 0);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -772,7 +862,15 @@ async function main() {
   console.log(`Endpoint : ${ENDPOINT}`);
   console.log(`Project  : ${PROJECT_ID}`);
   console.log(`Database : ${DATABASE_ID}`);
-  console.log(`Mode     : ${VERIFY_ONLY ? 'VERIFY (قراءة فقط)' : 'SETUP (إنشاء/تحديث)'}`);
+  console.log(
+    `Mode     : ${
+      FIX_TYPES
+        ? 'FIX-TYPES (هدمي: حذف+إعادة إنشاء)'
+        : VERIFY_ONLY
+          ? 'VERIFY (قراءة فقط)'
+          : 'SETUP (إنشاء/تحديث)'
+    }`,
+  );
   console.log(`Targets  : ${targets.length} مجموعة${ONLY ? ' (مُصفّاة)' : ''}`);
   console.log('═══════════════════════════════════════════════════════════');
 
@@ -780,6 +878,11 @@ async function main() {
 
   if (VERIFY_ONLY) {
     await verify(targets);
+    return;
+  }
+
+  if (FIX_TYPES) {
+    await fixTypes(targets);
     return;
   }
 

--- a/scripts/appwrite/unified_appwrite_setup.js
+++ b/scripts/appwrite/unified_appwrite_setup.js
@@ -63,6 +63,10 @@ const VERIFY_ONLY = ARGV.includes('--verify');
 // الصحيح (Appwrite لا يسمح بتغيير نوع سمة في مكانها). ⚠️ عملية هدمية: تُفقد قيم
 // ذلك العمود على السحابة وتُعاد من التخزين المحلي عند المزامنة التالية.
 const FIX_TYPES = ARGV.includes('--fix-types');
+// ✅ تأكيد صريح لتفادي تشغيل --fix-types بالخطأ. عند غيابه، يُطبَع تحذير ويُنتظر
+// 5 ثوانٍ مع عدّ تنازلي قبل البدء — يُلغى المستخدم بالـ Ctrl+C.
+// تمرير --confirm أو -y يتخطّى الانتظار (مناسب للسكربتات الآلية / CI).
+const CONFIRM = ARGV.includes('--confirm') || ARGV.includes('-y');
 const ONLY_ARG = ARGV.find((a) => a.startsWith('--only='));
 const ONLY = ONLY_ARG
   ? ONLY_ARG.replace('--only=', '').split(',').map((s) => s.trim()).filter(Boolean)
@@ -556,11 +560,9 @@ function stringSize(field) {
     // الصف (off-page) فلا يُحسب ضمن حدّ حجم صف Appwrite.
     config_json: 65535,
     permissions: 2000, // app_users: قائمة صلاحيات مُرمّزة JSON
-    api_key: 2000,
-    wa_api_token: 2000,
-    telegram_bot_token: 2000,
-    wa_sendzen_api_key: 2000,
-    wa_custom_url_template: 2000,
+    // ✅ تنظيف: حذف api_key, wa_api_token, telegram_bot_token, wa_sendzen_api_key,
+    //    wa_custom_url_template — كلها انتقلت إلى config_json (الخيار 2) ولم تعد
+    //    أعمدة منفصلة في أي SCHEMA. إبقاؤها هنا يُضلّل القارئ ويوحي بأنها مستخدمة.
     financialHash: 128,
   };
   if (explicit[field] != null) return explicit[field];
@@ -882,6 +884,25 @@ async function main() {
   }
 
   if (FIX_TYPES) {
+    // ✅ تأكيد هدمي: --fix-types يحذف أعمدة ويُعيد إنشاءها (يُفقد قيمها على السحابة).
+    // إن لم يُمرَّر --confirm/-y، نُطبِع تحذيراً صريحاً وننتظر 5 ثوانٍ مع عدّ تنازلي
+    // قبل البدء. هذا يمنع التشغيل العرضي (مثلاً نسخ أمر من README وتشغيله سريعاً).
+    if (!CONFIRM) {
+      console.log('═══════════════════════════════════════════════════════════');
+      console.log('⚠️  تحذير: وضع FIX-TYPES هدمي!');
+      console.log('   سيتم حذف كل سمة نوعها غير مطابق لإعادة إنشائها بالنوع الصحيح.');
+      console.log('   قيم تلك الأعمدة ستُفقد على السحابة (تُعاد محلياً عند المزامنة).');
+      console.log('   للإلغاء اضغط Ctrl+C خلال 5 ثوانٍ...');
+      console.log('   (لتخطّي هذا التحذير مستقبلاً: أضِف --confirm أو -y)');
+      console.log('═══════════════════════════════════════════════════════════');
+      for (let i = 5; i > 0; i--) {
+        process.stdout.write(`\r   البدء خلال ${i} ثانية...  `);
+        await sleep(1000);
+      }
+      process.stdout.write('\r   ▶ البدء الآن.                  \n');
+    } else {
+      console.log('⚠️  FIX-TYPES (تم تخطّي التحذير عبر --confirm)');
+    }
     await fixTypes(targets);
     return;
   }

--- a/scripts/appwrite/unified_appwrite_setup.js
+++ b/scripts/appwrite/unified_appwrite_setup.js
@@ -461,26 +461,19 @@ const SCHEMA = {
     endpoint: 'string',
     project_id: 'string',
     database_id: 'string',
-    api_key: 'string',
     enabled: 'boolean',
     push_enabled: 'boolean',
     pull_enabled: 'boolean',
     appwrite_auto_sync_on_connect: 'boolean',
     appwrite_log_console: 'boolean',
     appwrite_log_file: 'boolean',
-    appwrite_log_level: 'string',
-    // WhatsApp
-    wa_api_type: 'string',
-    wa_api_base_url: 'string',
-    wa_api_instance_id: 'string',
-    wa_api_token: 'string',
-    wa_custom_url_template: 'string',
-    wa_sendzen_api_key: 'string',
-    wa_sendzen_from_number: 'string',
-    // Telegram
+    // ✅ الخيار 2: كل مفاتيح WhatsApp/Telegram/API النصية الحسّاسة مُجمّعة
+    // في حقل JSON واحد (config_json) بدل ~11 عموداً نصياً منفصلاً — لتفادي
+    // تجاوز حدّ حجم الصف (row-size) في Appwrite. يُنشأ بحجم كبير (TEXT خارج
+    // الصف) فلا يستهلك من ميزانية الصف عملياً.
+    config_json: 'string',
+    // Telegram — المفاتيح المنطقية (bool) تبقى أعمدة؛ النصّية داخل config_json
     telegram_enabled: 'boolean',
-    telegram_bot_token: 'string',
-    telegram_chat_id: 'string',
     telegram_notifications_enabled: 'boolean',
     telegram_daily_report_enabled: 'boolean',
     telegram_daily_report_time: 'string',
@@ -552,6 +545,9 @@ function stringSize(field) {
     vectorClock: 2000,
     secondary_appwrite_config: 8000,
     appliedAdjustmentsJson: 8000,
+    // config_json: مُجمّع إعدادات app_settings — حجم كبير ليُخزَّن TEXT خارج
+    // الصف (off-page) فلا يُحسب ضمن حدّ حجم صف Appwrite.
+    config_json: 65535,
     permissions: 2000, // app_users: قائمة صلاحيات مُرمّزة JSON
     api_key: 2000,
     wa_api_token: 2000,


### PR DESCRIPTION
- feat(app_settings): consolidate WhatsApp/Telegram config into single config_json attribute

app_settings exceeded Appwrite's per-collection row-size limit (~64KB),
so 11 string config attributes (wa_*, telegram tokens, api_key,
appwrite_log_level) could not be created — causing recurring
"Missing/Unknown attribute" errors on both primary and secondary.

Option 2 fix: replace the many heavy string columns with a single
off-page `config_json` TEXT attribute (size 65535 → stored off-row, so
it costs almost nothing against the row budget).

- unified_appwrite_setup.js: remove the 11 overflowing string fields from
  app_settings SCHEMA, add config_json; stringSize(config_json)=65535 to
  force off-page TEXT storage.
- appwrite_sync_manager: push serializes _appSettingsConfigKeys into
  config_json (removing individual keys); pull decodes config_json back
  into `data` via putIfAbsent so the existing per-field restore logic is
  unchanged and remains backward compatible with legacy columns.
- secondary_appwrite_service: same consolidation in _appSettingsToMap
  (+ dart:convert import).
- appwrite_sync_utils: add config_json to app_settings valid fields so the
  push filter keeps it.

Provisioned and verified on both targets: app_settings now 42/42 fields,
0 missing on primary and secondary.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
- fix(appwrite): make sync field TYPES identical across primary, secondary, and code

--verify only checked field existence, not type, so type drift went
undetected and caused "invalid type" push errors (e.g. shift_notes.createdAt
was string on primary but integer everywhere else).

Changes:
- unified_appwrite_setup.js:
  * verify() now also compares each attribute's actual Appwrite type
    against SCHEMA and reports/count mismatches (exit non-zero).
  * new --fix-types mode: deletes each type-mismatched attribute and
    recreates it with the correct SCHEMA type (Appwrite can't alter a
    type in place). Destructive per-column only; values re-sync from local.
- Align SCHEMA + Dart collectionSchema to the deployed reality for three
  fields that were double on BOTH clouds while SCHEMA said integer
  (price_adjustments.previousValue/newValue, audit_logs.amountImpact).
  Pull adapters convert double->int via _asInt/.toInt, so this is safe
  and avoids destroying audit history.

Applied to the live targets:
- Secondary: 0 type mismatches (the 3 shared fields now match SCHEMA=double).
- Primary: recreated the 8 primary-only drifted attributes
  (debts.amount->double, booking_notes.isActive->boolean,
  cash_transactions.createdBy->string, salary_cycles.{expectedAmount,
  actualPaid,remainingAmount}->integer, salary_payments.amount->integer,
  shift_notes.createdAt->integer). Verified: 0 type mismatches on both.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>