### PR TITLE
fix(test): align smart_conflict_resolver tests with LWW design decision

### DIFF
--- a/mobile/test/unit/smart_conflict_resolver_test.dart
+++ b/mobile/test/unit/smart_conflict_resolver_test.dart
@@ -151,7 +151,7 @@ void main() {
         expect(result.mergedData['status'], equals('remote_status'));
       });
 
-      test('concurrentSameFields with critical field escalates to manual', () {
+      test('concurrentSameFields with critical field resolves via LWW (not manual)', () {
         final result = SmartConflictResolver.resolve(
           entity: 'expenses',
           localData: {
@@ -170,7 +170,12 @@ void main() {
             'lastModified': 500,
           },
         );
-        expect(result.strategy, equals(ResolutionStrategy.manualEscalation));
+        expect(result.strategy, equals(ResolutionStrategy.fieldLevelMerge));
+        // After commit fffa6a37 ("fully automatic conflict resolution"),
+        // critical fields no longer escalate to manual. Instead they resolve
+        // via LWW (Last Write Wins) inside fieldLevelMerge.
+        // The remote has lastModified=2000 > local=1000, so remote value wins.
+        expect(result.mergedData?['amount'], equals(200.0));
         expect(result.warnings, isNotEmpty);
       });
     });
@@ -362,7 +367,7 @@ void main() {
         expect(result.mergedData['status'], equals('remote'));
       });
 
-      test('rooms: price escalates to manual', () {
+      test('rooms: price resolves via LWW (not manual)', () {
         final result = SmartConflictResolver.resolve(
           entity: 'rooms',
           localData: {
@@ -381,10 +386,14 @@ void main() {
             'lastModified': 500,
           },
         );
-        expect(result.strategy, equals(ResolutionStrategy.manualEscalation));
+        expect(result.strategy, equals(ResolutionStrategy.fieldLevelMerge));
+        // After commit fffa6a37, 'price' on rooms uses LWW instead of manual escalation.
+        // Remote (lastModified=2000) is newer than local (lastModified=1000),
+        // so the remote price (200.0) should win.
+        expect(result.mergedData?['price'], equals(200.0));
       });
 
-      test('payments: amount escalates to manual', () {
+      test('payments: amount resolves via LWW (not manual)', () {
         final result = SmartConflictResolver.resolve(
           entity: 'payments',
           localData: {
@@ -403,10 +412,14 @@ void main() {
             'lastModified': 500,
           },
         );
-        expect(result.strategy, equals(ResolutionStrategy.manualEscalation));
+        expect(result.strategy, equals(ResolutionStrategy.fieldLevelMerge));
+        // After commit fffa6a37, 'amount' on payments uses LWW instead of manual escalation.
+        // Remote (lastModified=2000) is newer than local (lastModified=1000),
+        // so the remote amount (200.0) should win.
+        expect(result.mergedData?['amount'], equals(200.0));
       });
 
-      test('debts: all fields escalate to manual', () {
+      test('debts: all fields resolve via LWW (not manual)', () {
         final result = SmartConflictResolver.resolve(
           entity: 'debts',
           localData: {
@@ -425,7 +438,11 @@ void main() {
             'lastModified': 500,
           },
         );
-        expect(result.strategy, equals(ResolutionStrategy.manualEscalation));
+        expect(result.strategy, equals(ResolutionStrategy.fieldLevelMerge));
+        // After commit fffa6a37, 'totalAmount' on debts uses LWW instead of manual escalation.
+        // Remote (lastModified=2000) is newer than local (lastModified=1000),
+        // so the remote totalAmount (200.0) should win.
+        expect(result.mergedData?['totalAmount'], equals(200.0));
       });
 
       test('unknown entity uses default policy (newerWins)', () {


### PR DESCRIPTION
## **User description**
# Summary

Fixes 4 unit tests in `smart_conflict_resolver_test.dart` that have been failing since commit `fffa6a37` (2026-07-01) which intentionally removed manual escalation in favor of fully automatic conflict resolution.

The tests still expected `ResolutionStrategy.manualEscalation`, but the implementation now returns `ResolutionStrategy.fieldLevelMerge` with LWW (Last Write Wins) resolution.

---

## Background

Commit `fffa6a37` ("feat: fully automatic conflict resolution (no manual escalation)") made a deliberate design decision:

> Eliminated ALL manual conflict escalation — every conflict is now resolved automatically without user intervention.

Two changes in `SmartConflictResolver`:
1. `FieldStrategy.manual` now uses LWW (Last Write Wins) instead of keeping local value + escalating
2. `_escalateManual()` returns `fieldLevelMerge` with LWW resolution instead of `manualEscalation`

The 4 affected tests were never updated to reflect this decision, causing them to fail on every CI run for the past 10 days.

---

## Changes

4 tests updated (no production code changed):

| # | Old name | New name | New assertion |
|---|---|---|---|
| 1 | `concurrentSameFields with critical field escalates to manual` | `concurrentSameFields with critical field resolves via LWW (not manual)` | `strategy == fieldLevelMerge` + `mergedData.amount == 200.0` |
| 2 | `rooms: price escalates to manual` | `rooms: price resolves via LWW (not manual)` | `strategy == fieldLevelMerge` + `mergedData.price == 200.0` |
| 3 | `payments: amount escalates to manual` | `payments: amount resolves via LWW (not manual)` | `strategy == fieldLevelMerge` + `mergedData.amount == 200.0` |
| 4 | `debts: all fields escalate to manual` | `debts: all fields resolve via LWW (not manual)` | `strategy == fieldLevelMerge` + `mergedData.totalAmount == 200.0` |

Each updated test now also verifies the actual merged value (not just the strategy), which gives **stronger coverage** of the LWW behavior: when remote `lastModified` > local `lastModified`, the remote value should win.

---

## Verification

```
$ flutter test test/unit/smart_conflict_resolver_test.dart

Before:  +16 -4  (4 failures)
After:   +20 -0  (all pass)
```

All 20 tests in the file now pass. No production code was changed.

---

## Test plan

- [x] `flutter test test/unit/smart_conflict_resolver_test.dart` — all 20 pass
- [ ] CI: full `flutter test test/unit/` shows 0 failures (was +241 −4, should now be +245 −0)

---

/cc @NassarAlshabi1


___

## **CodeAnt-AI Description**
Update conflict resolver tests to match automatic LWW behavior

### What Changed
- Renamed tests that expected manual conflict handling so they now describe last-write-wins resolution
- Updated the affected cases to expect field-level merge instead of manual escalation
- Added checks for the actual merged value, confirming the newer remote value wins in each case

### Impact
`✅ Fewer failing unit tests`
`✅ Clearer conflict resolution expectations`
`✅ Stronger coverage of last-write-wins behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
