### PR TITLE
fix(sync): break rate-limit feedback loop causing 90+ 429 errors

### DIFF
--- a/mobile/lib/services/appwrite_network_helper.dart
+++ b/mobile/lib/services/appwrite_network_helper.dart
@@ -25,32 +25,54 @@ class AppwriteNetworkHelper {
   // Rate Limiter (token bucket) — يضمن تأخيراً أدنى بين الطلبات المتتالية.
   // Appwrite Cloud يفرض حدوداً لكل مشروع/مستخدم؛ التأخير الأدنى يقلل
   // احتمال تجاوزها في push flow حيث تتوالى updateDocument بشكل مكثّف.
+  //
+  // ✅ إصلاح (2026-07-11): رفع التأخير من 120ms إلى 600ms (1.6 req/s)
+  // لأن Appwrite Cloud Free tier يفرض ~2 req/s. الـ 120ms السابق (8.3 req/s)
+  // كان يسبب إغراق السيرفر بـ 429s متتالية.
   // ─────────────────────────────────────────────────────────────────────
-  static const Duration _minRequestInterval = Duration(milliseconds: 120);
+  static const Duration _minRequestInterval = Duration(milliseconds: 600);
   DateTime _lastRequestTime =
       DateTime.fromMillisecondsSinceEpoch(0);
 
   // ─────────────────────────────────────────────────────────────────────
   // Circuit Breaker — يحمي من إغراق الخادم عند تكرار 429.
+  //
+  // ✅ إصلاح (2026-07-11): progressive cooldown بدلاً من 60s ثابت.
+  // كل تفعيل جديد يضاعف المدة: 60s → 120s → 300s → 600s → 600s...
+  // هذا يمنع الحلقة المفرغة حيث يُعاد تفعيله فوراً بعد انتهاء الـ 60s.
   // ─────────────────────────────────────────────────────────────────────
   int _consecutiveRateLimitHits = 0;
   static const int _circuitBreakerThreshold = 5;
   DateTime? _circuitBreakerUntil;
-  static const Duration _circuitBreakerCooldown = Duration(seconds: 60);
+  int _circuitBreakerActivationCount = 0; // لزيادة المدة تدريجياً
+  static const List<Duration> _progressiveCooldowns = [
+    Duration(seconds: 60),
+    Duration(seconds: 120),
+    Duration(seconds: 300),
+    Duration(seconds: 600),
+  ];
 
   /// ينتظر حتى يصبح مسموحاً بإطلاق طلب جديد (للحفاظ على rate limit).
+  ///
+  /// ✅ إصلاح حرج (2026-07-11): بدلاً من رمي AppwriteException(429) عندما
+  /// الـ circuit breaker مفعّل (مما يسبب حلقة مفرغة — الاستثناء يُلتقط
+  /// في withRetry ويُعامل كـ 429 جديد فيزيد العداد)، ننتظر فعلياً حتى
+  /// انتهاء فترة التهدئة ثم نُكمل. هذا يكسر الحلقة المفرغة.
   Future<void> _acquireRequestSlot() async {
-    // 1) فحص circuit breaker
+    // 1) فحص circuit breaker — انتظر بدلاً من رمي استثناء
     if (_circuitBreakerUntil != null) {
       final now = DateTime.now();
       if (now.isBefore(_circuitBreakerUntil!)) {
         final remaining = _circuitBreakerUntil!.difference(now);
-        throw AppwriteException(
-          'Circuit breaker active — rate limit cooldown. '
-          'Retry in ${remaining.inSeconds}s.',
-          429,
-          'general_rate_limit_exceeded',
+        _logger.warning(
+          '⏳ Circuit breaker active — waiting ${remaining.inSeconds}s '
+          'before next request (instead of throwing 429)',
+          tag: 'RATE_LIMIT',
         );
+        await Future<void>.delayed(remaining);
+        // بعد الانتظار، أعد الضبط
+        _circuitBreakerUntil = null;
+        _consecutiveRateLimitHits = 0;
       } else {
         // انتهت فترة التهدئة — أعد الضبط
         _circuitBreakerUntil = null;
@@ -60,8 +82,6 @@ class AppwriteNetworkHelper {
 
     // 2) احترام التأخير الأدنى بين الطلبات
     // ✅ إصلاح سباق: نحجز فتحة الطلب التالية بشكل متزامن *قبل* الـ await.
-    // خلاف ذلك، الطلبات المتزامنة تقرأ نفس _lastRequestTime وتنطلق معًا،
-    // مما يُبطل مفعول محدّد المعدّل. بتحديث _lastRequestTime فورًا نُسلسل الطلبات.
     final now = DateTime.now();
     final scheduledTime = _lastRequestTime.add(_minRequestInterval).isAfter(now)
         ? _lastRequestTime.add(_minRequestInterval)
@@ -74,21 +94,35 @@ class AppwriteNetworkHelper {
   }
 
   /// يُستدعى عند نجاح أي طلب — يصفّر عدّاد circuit breaker.
+  ///
+  /// ✅ إصلاح (2026-07-11): عند النجاح، أعد ضبط عدّاد التفعيلات أيضاً
+  /// حتى لا يستمر progressive cooldown في الزيادة بعد التعافي.
   void _onRequestSuccess() {
     if (_consecutiveRateLimitHits > 0) {
       _consecutiveRateLimitHits = 0;
     }
+    if (_circuitBreakerActivationCount > 0) {
+      _circuitBreakerActivationCount = 0;
+    }
   }
 
-  /// يُستدعى عند تلقي 429 — يحدّث circuit breaker.
+  /// يُستدعى عند تلقي 429 من السيرفر (وليس من circuit breaker محلي).
+  ///
+  /// ✅ إصلاح (2026-07-11): progressive cooldown — كل تفعيل جديد يزيد المدة.
+  /// هذا يمنع إعادة التفعيل الفورية بعد انتهاء الـ 60s.
   void _onRateLimitHit() {
     _consecutiveRateLimitHits++;
     if (_consecutiveRateLimitHits >= _circuitBreakerThreshold) {
-      _circuitBreakerUntil =
-          DateTime.now().add(_circuitBreakerCooldown);
+      // ✅ progressive cooldown: 60s → 120s → 300s → 600s
+      final cooldownIndex = _circuitBreakerActivationCount
+          .clamp(0, _progressiveCooldowns.length - 1);
+      final cooldown = _progressiveCooldowns[cooldownIndex];
+      _circuitBreakerActivationCount++;
+      _circuitBreakerUntil = DateTime.now().add(cooldown);
       _logger.error(
-        '🔌 Circuit breaker ACTIVATED for ${_circuitBreakerCooldown.inSeconds}s '
-        'after $_consecutiveRateLimitHits consecutive 429s',
+        '🔌 Circuit breaker ACTIVATED for ${cooldown.inSeconds}s '
+        'after $_consecutiveRateLimitHits consecutive 429s '
+        '(activation #$_circuitBreakerActivationCount)',
         tag: 'RATE_LIMIT',
       );
     }
@@ -427,11 +461,14 @@ class AppwriteNetworkHelper {
 
   /// ✅ جديد: حالة الـ circuit breaker — يُستخدم من sync manager لإيقاف
   /// المزامنة مؤقتاً عند تفعّله.
+  ///
+  /// ✅ إصلاح (2026-07-11): أعد ضبط عدّاد التفعيلات عند انتهاء الـ cooldown.
   bool get isCircuitBreakerActive {
     if (_circuitBreakerUntil == null) return false;
     if (DateTime.now().isBefore(_circuitBreakerUntil!)) return true;
     _circuitBreakerUntil = null;
     _consecutiveRateLimitHits = 0;
+    _circuitBreakerActivationCount = 0;
     return false;
   }
 

--- a/mobile/lib/services/secondary_sync_manager.dart
+++ b/mobile/lib/services/secondary_sync_manager.dart
@@ -4,6 +4,7 @@ import 'package:appwrite/appwrite.dart';
 import 'package:drift/drift.dart' as drift;
 import 'package:flutter/foundation.dart';
 import 'appwrite_config.dart';
+import 'appwrite_network_helper.dart';
 import 'appwrite_sync_utils.dart';
 import 'daos/outbox_dao.dart';
 import 'local_db.dart';
@@ -203,6 +204,20 @@ class SecondarySyncManager {
       // ✅ P0-1 + P1-5: حلقة آمنة مع backoff بين الدورات
       int emptyLoopsInRow = 0;
       while (true) {
+        // ✅ إصلاح (2026-07-11): توقف فوري إذا كان network circuit breaker
+        // مفعّلاً — لا نلتقط سجلات جديدة وندعها تتراكم للمزامنة القادمة.
+        // هذا يمنع الحلقة المفرغة: 429 → circuit breaker → محاولة جديدة → 429.
+        if (AppwriteNetworkHelper().isCircuitBreakerActive) {
+          final remaining = AppwriteNetworkHelper().circuitBreakerRemaining;
+          debugPrint(
+            '🔌 [SecondarySync] Network circuit breaker active '
+            '(remaining ${remaining?.inSeconds ?? 0}s) — '
+            'stopping sync to avoid rate limit loop. '
+            '$pushed pushed, $failed failed so far.',
+          );
+          break;
+        }
+
         // ✅ P0-1: نستبعد السجلات المُعالَجة في هذه الجلسة من الالتقاط
         final entries = await _takeUndeliveredBatch(
           db,


### PR DESCRIPTION
## **User description**
# Summary

Fixes a **critical feedback loop** in the circuit breaker that caused 90+ consecutive 429 errors in 5 minutes (per user logs).

## Root cause

The circuit breaker was **counting its own thrown exceptions as new 429s**, creating an infinite loop:

```
1. Request → Appwrite returns 429
2. _onRateLimitHit() increments counter → circuit breaker activates (after 5)
3. Next request → _acquireRequestSlot() THROWS AppwriteException(429)
4. This exception caught in withRetry → _isRateLimitError(e) = TRUE
5. _onRateLimitHit() increments counter AGAIN
6. Goto step 3 — infinite loop
```

Each retry attempt during circuit breaker added another "429" to the counter, causing it to re-activate immediately after the 60s cooldown expired.

## Fixes (5 changes, 2 files)

| # | Fix | File |
|---|---|---|
| 1 | `_acquireRequestSlot()` — **wait** instead of **throw** when circuit breaker active | `appwrite_network_helper.dart` |
| 2 | Progressive cooldown: 60s → 120s → 300s → 600s (was fixed 60s) | `appwrite_network_helper.dart` |
| 3 | Min request interval: 120ms → 600ms (1.6 req/s, under Appwrite's ~2 req/s limit) | `appwrite_network_helper.dart` |
| 4 | Reset activation counter on success | `appwrite_network_helper.dart` |
| 5 | SecondarySyncManager — stop pulling entries when circuit breaker active | `secondary_sync_manager.dart` |

## Verification

- `flutter analyze`: 63 issues (0 errors) — same as baseline
- `secondary_sync_manager_test`: +9 all pass
- `sync_orchestrator_test`: +17 all pass
- `adapters_round_trip_test`: +2 all pass

## Expected impact

**Before**: 90 consecutive 429s in 5 min, circuit breaker re-activating every 60s, sync effectively stuck in error loop

**After**:
- First 429 batch → 60s cooldown (waits, doesn't throw)
- If 429s persist after cooldown → 120s → 300s → 600s
- Sync loop exits cleanly when circuit breaker active
- Rate limiter prevents initial 429 flood (1.6 req/s vs 8.3 req/s)

## Test plan

- [x] `flutter analyze` — 0 errors
- [x] Unit tests pass (28 tests across 3 files)
- [ ] Manual: trigger secondary sync and verify no 429 flood in logs
- [ ] Manual: verify sync resumes normally after cooldown expires


___

## **CodeAnt-AI Description**
**Stop sync loops from repeatedly triggering rate limits**

### What Changed
- Secondary sync now stops pulling new items when the network circuit breaker is active, so queued changes wait for the next run instead of feeding a 429 loop.
- When the circuit breaker is active, requests now wait for the cooldown to finish instead of failing immediately with another 429.
- Rate-limit protection now uses a longer minimum gap between requests and longer cooldowns after repeated failures, reducing repeat 429 bursts.
- After a successful request or when the cooldown expires, the rate-limit counters reset so recovery is not blocked by old failures.

### Impact
`✅ Fewer repeated 429 errors`
`✅ Shorter sync interruptions`
`✅ Less backlog churn during rate limits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
